### PR TITLE
Null ClientWidth on Resize

### DIFF
--- a/src/components/Graph/Graph.tsx
+++ b/src/components/Graph/Graph.tsx
@@ -221,6 +221,7 @@ const GraphMemo: FC<GraphMemoProps> = memo(
                   name={nodeName}
                   ref={(node: HTMLDivElement): void => {
                     if (node) nodeRefs.current[nodeName] = node;
+                    else delete nodeRefs.current[nodeName];
                   }}
                   pathwayState={pathway.states[nodeName]}
                   isCurrentNode={false}

--- a/src/components/Graph/Graph.tsx
+++ b/src/components/Graph/Graph.tsx
@@ -43,14 +43,18 @@ const Graph: FC<GraphProps> = memo(({ pathway, interactive = true, expandCurrent
     if (nodeRefs?.current) {
       Object.keys(nodeRefs.current).forEach(key => {
         const nodeElement = nodeRefs.current[key];
-        const width = nodeElement.clientWidth;
-        // nodeElement can have multiple children so calculate the sum to get the node height
-        const height = Array.from(nodeElement.children).reduce(
-          (acc, child) => acc + child.clientHeight,
-          0
-        );
+        if (nodeElement) {
+          const width = nodeElement.clientWidth;
+          // nodeElement can have multiple children so calculate the sum to get the node height
+          const height = Array.from(nodeElement.children).reduce(
+            (acc, child) => acc + child.clientHeight,
+            0
+          );
 
-        nodeDimensions[key] = { width, height };
+          nodeDimensions[key] = { width, height };
+        } else {
+          debugger;
+        }
       });
     }
 
@@ -220,7 +224,7 @@ const GraphMemo: FC<GraphMemoProps> = memo(
                   key={nodeName}
                   name={nodeName}
                   ref={(node: HTMLDivElement): void => {
-                    nodeRefs.current[nodeName] = node;
+                    if (node) nodeRefs.current[nodeName] = node;
                   }}
                   pathwayState={pathway.states[nodeName]}
                   isCurrentNode={false}

--- a/src/components/Graph/Graph.tsx
+++ b/src/components/Graph/Graph.tsx
@@ -43,18 +43,14 @@ const Graph: FC<GraphProps> = memo(({ pathway, interactive = true, expandCurrent
     if (nodeRefs?.current) {
       Object.keys(nodeRefs.current).forEach(key => {
         const nodeElement = nodeRefs.current[key];
-        if (nodeElement) {
-          const width = nodeElement.clientWidth;
-          // nodeElement can have multiple children so calculate the sum to get the node height
-          const height = Array.from(nodeElement.children).reduce(
-            (acc, child) => acc + child.clientHeight,
-            0
-          );
+        const width = nodeElement.clientWidth;
+        // nodeElement can have multiple children so calculate the sum to get the node height
+        const height = Array.from(nodeElement.children).reduce(
+          (acc, child) => acc + child.clientHeight,
+          0
+        );
 
-          nodeDimensions[key] = { width, height };
-        } else {
-          debugger;
-        }
+        nodeDimensions[key] = { width, height };
       });
     }
 


### PR DESCRIPTION
Resizing the window would cause an error because the nodeRef was null. I played around with it a lot and noticed whenever the screen resized the nodes were being set to null. I'm not exactly sure why but adding a check so the ref isn't updated when it is null seems to fix the issue.

To test create a new pathway and add at least one new node. Then resize the screen. No error is thrown and the nodes stay centered in the window.