### PR TITLE
Fix arrow rendering

### DIFF
--- a/src/components/Graph/Graph.tsx
+++ b/src/components/Graph/Graph.tsx
@@ -94,8 +94,8 @@ const Graph: FC<GraphProps> = memo(({ pathway, interactive = true, expandCurrent
   const maxWidth = useMemo(() => {
     return nodeCoordinates !== undefined
       ? Object.values(nodeCoordinates)
-          // Add 250 to account for expanded node width
-          .map(x => x.x + parentWidth / 2 + 250)
+          // Add width of the node to account for x coordinate starting at top left corner
+          .map(x => x.x + parentWidth / 2 + (x.width ?? 0))
           .reduce((a, b) => Math.max(a, b))
       : 0;
   }, [nodeCoordinates, parentWidth]);

--- a/src/components/Graph/Graph.tsx
+++ b/src/components/Graph/Graph.tsx
@@ -90,6 +90,16 @@ const Graph: FC<GraphProps> = memo(({ pathway, interactive = true, expandCurrent
     });
   }
 
+  // Find node that is farthest to the right
+  const maxWidth = useMemo(() => {
+    return nodeCoordinates !== undefined
+      ? Object.values(nodeCoordinates)
+          // Add 250 to account for expanded node width
+          .map(x => x.x + parentWidth / 2 + 250)
+          .reduce((a, b) => Math.max(a, b))
+      : 0;
+  }, [nodeCoordinates, parentWidth]);
+
   const [expanded, setExpanded] = useState<ExpandedState>(() =>
     Object.keys(layout).reduce(
       (acc, curr: string) => {
@@ -123,15 +133,6 @@ const Graph: FC<GraphProps> = memo(({ pathway, interactive = true, expandCurrent
   useEffect(() => {
     setLayout(getGraphLayout());
   }, [pathway, expanded, getGraphLayout]);
-
-  // maxWidth finds the edge label that is farthest to the right
-  const maxWidth: number =
-    edges !== undefined
-      ? Object.values(edges)
-          .map(e => e.label)
-          .map(l => (l ? l.x + l.text.length * 10 + parentWidth / 2 : 0))
-          .reduce((a, b) => Math.max(a, b), 0)
-      : parentWidth;
 
   return (
     <GraphMemo
@@ -200,7 +201,6 @@ const GraphMemo: FC<GraphMemoProps> = memo(
       },
       [redirectToNode, toggleExpanded, interactive]
     );
-
     return (
       <div
         ref={graphElement}
@@ -237,8 +237,7 @@ const GraphMemo: FC<GraphMemoProps> = memo(
         <svg
           xmlns="http://www.w3.org/2000/svg"
           style={{
-            // Adding 5 pixels to maxWidth so that the rightmost edge label is not cut off
-            width: maxWidth + 5,
+            width: maxWidth,
             height: maxHeight,
             zIndex: 1,
             top: 0,

--- a/src/types/graph-model.d.ts
+++ b/src/types/graph-model.d.ts
@@ -18,7 +18,7 @@ declare module 'graph-model' {
   }
 
   export interface NodeCoordinates {
-    [key: string]: Coordinate;
+    [key: string]: Coordinate & { width?: number };
   }
 
   export interface Coordinate {

--- a/src/visualization/layout.ts
+++ b/src/visualization/layout.ts
@@ -76,7 +76,8 @@ function layoutDagre(pathway: Pathway, nodeDimensions: NodeDimensions): Layout {
     // further, our renderer expects the Start node to be centered at x: 0
     nodeCoordinates[nodeName] = {
       x: node.x - startNodeShift - node.width / 2,
-      y: node.y - node.height / 2
+      y: node.y - node.height / 2,
+      width: node.width
     };
   }
 


### PR DESCRIPTION
Modified the method we used to calculate `maxWidth`. Previously we depended on the edge label farthest to the right to determine the width for the arrow svgs so the arrows were not appearing when there were no edge labels. I changed it to use the node farthest to right instead.

![image](https://user-images.githubusercontent.com/6588796/84536927-d83e1d80-acbc-11ea-9cfd-cbc302e49df3.png)
