### PR TITLE
Build criteria flow

### DIFF
--- a/src/components/Builder/Builder.module.scss
+++ b/src/components/Builder/Builder.module.scss
@@ -1,9 +1,0 @@
-.display {
-  display: flex;
-}
-
-.graph {
-  width: 100%;
-  height: 100%;
-  overflow-y: scroll;
-}

--- a/src/components/Builder/Builder.tsx
+++ b/src/components/Builder/Builder.tsx
@@ -21,7 +21,7 @@ interface BuilderProps {
 
 const Builder: FC<BuilderProps> = ({ pathway, currentNode }) => {
   const styles = useStyles();
-  const { buildCriteria } = useCriteriaContext();
+  const { buildCriteriaNodeId } = useCriteriaContext();
   const headerElement = useRef<HTMLDivElement>(null);
   const graphContainerElement = useRef<HTMLDivElement>(null);
   const theme = useTheme('dark');
@@ -38,6 +38,11 @@ const Builder: FC<BuilderProps> = ({ pathway, currentNode }) => {
         window.innerHeight - headerElement.current.clientHeight + 'px';
   }, [pathway, headerElement, graphContainerElement]);
 
+  // Reset criteriaBuilderToggle to true if not currently building criteria
+  useEffect(() => {
+    if (!criteriaBuilderToggle && buildCriteriaNodeId === '') setCriteriaBuilderToggle(true);
+  }, [buildCriteriaNodeId, criteriaBuilderToggle]);
+
   return (
     <>
       <div ref={headerElement}>
@@ -52,7 +57,7 @@ const Builder: FC<BuilderProps> = ({ pathway, currentNode }) => {
 
         <div ref={graphContainerElement} className={styles.graph}>
           <div className={styles.graphHeader}>
-            {buildCriteria && (
+            {buildCriteriaNodeId !== '' && (
               <>
                 <div className={styles.graphHeaderText}>
                   <span>Criteria Builder</span>
@@ -66,7 +71,7 @@ const Builder: FC<BuilderProps> = ({ pathway, currentNode }) => {
               </>
             )}
           </div>
-          {buildCriteria && criteriaBuilderToggle ? (
+          {buildCriteriaNodeId !== '' && criteriaBuilderToggle ? (
             // Empty section for authoring tool
             <div />
           ) : (

--- a/src/components/Builder/Builder.tsx
+++ b/src/components/Builder/Builder.tsx
@@ -25,11 +25,11 @@ const Builder: FC<BuilderProps> = ({ pathway, currentNode }) => {
   const headerElement = useRef<HTMLDivElement>(null);
   const graphContainerElement = useRef<HTMLDivElement>(null);
   const theme = useTheme('dark');
-  const [criteriaBuilderToggle, setCriteriaBuilderToggle] = useState<boolean>(true);
+  const [showCriteriaBuilder, setShowCriteriaBuilder] = useState<boolean>(true);
 
-  const handleToggle = useCallback((): void => {
-    setCriteriaBuilderToggle(!criteriaBuilderToggle);
-  }, [criteriaBuilderToggle]);
+  const toggleShowCriteria = useCallback((): void => {
+    setShowCriteriaBuilder(!showCriteriaBuilder);
+  }, [showCriteriaBuilder]);
 
   // Set the height of the graph container
   useEffect(() => {
@@ -40,8 +40,8 @@ const Builder: FC<BuilderProps> = ({ pathway, currentNode }) => {
 
   // Reset criteriaBuilderToggle to true if not currently building criteria
   useEffect(() => {
-    if (!criteriaBuilderToggle && buildCriteriaNodeId === '') setCriteriaBuilderToggle(true);
-  }, [buildCriteriaNodeId, criteriaBuilderToggle]);
+    if (!showCriteriaBuilder && buildCriteriaNodeId === '') setShowCriteriaBuilder(true);
+  }, [buildCriteriaNodeId, showCriteriaBuilder]);
 
   return (
     <>
@@ -56,22 +56,20 @@ const Builder: FC<BuilderProps> = ({ pathway, currentNode }) => {
         </MuiThemeProvider>
 
         <div ref={graphContainerElement} className={styles.graph}>
-          <div className={styles.graphHeader}>
-            {buildCriteriaNodeId !== '' && (
-              <>
-                <div className={styles.graphHeaderText}>
-                  <span>Criteria Builder</span>
-                </div>
-                <IconButton
-                  className={`${styles.toggleButton}-${criteriaBuilderToggle ? 'on' : 'off'}`}
-                  onClick={handleToggle}
-                >
-                  <FontAwesomeIcon className={styles.toggleIcon} icon={faProjectDiagram} />
-                </IconButton>
-              </>
-            )}
-          </div>
-          {buildCriteriaNodeId !== '' && criteriaBuilderToggle ? (
+          {buildCriteriaNodeId !== '' && (
+            <div className={styles.graphHeader}>
+              <div className={styles.graphHeaderText}>
+                <span>Criteria Builder</span>
+              </div>
+              <IconButton
+                className={`${styles.toggleButton}-${showCriteriaBuilder ? 'on' : 'off'}`}
+                onClick={toggleShowCriteria}
+              >
+                <FontAwesomeIcon className={styles.toggleIcon} icon={faProjectDiagram} />
+              </IconButton>
+            </div>
+          )}
+          {buildCriteriaNodeId !== '' && showCriteriaBuilder ? (
             // Empty section for authoring tool
             <div />
           ) : (

--- a/src/components/Builder/Builder.tsx
+++ b/src/components/Builder/Builder.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useRef, useEffect, memo } from 'react';
+import React, { FC, useRef, useEffect, memo, useState, useCallback } from 'react';
 import { Pathway, State } from 'pathways-model';
 import { ThemeProvider as MuiThemeProvider } from '@material-ui/core/styles';
 
@@ -8,7 +8,10 @@ import Sidebar from 'components/Sidebar';
 import Graph from 'components/Graph';
 import { useTheme } from 'components/ThemeProvider';
 
-import styles from './Builder.module.scss';
+import { IconButton } from '@material-ui/core';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faToggleOff, faToggleOn } from '@fortawesome/free-solid-svg-icons';
+import useStyles from './styles';
 
 interface BuilderProps {
   pathway: Pathway;
@@ -16,9 +19,15 @@ interface BuilderProps {
 }
 
 const Builder: FC<BuilderProps> = ({ pathway, currentNode }) => {
+  const styles = useStyles();
   const headerElement = useRef<HTMLDivElement>(null);
   const graphContainerElement = useRef<HTMLDivElement>(null);
   const theme = useTheme('dark');
+  const [toggle, setToggle] = useState<boolean>(false);
+
+  const handleToggle = useCallback((): void => {
+    setToggle(!toggle);
+  }, [toggle]);
 
   // Set the height of the graph container
   useEffect(() => {
@@ -40,6 +49,14 @@ const Builder: FC<BuilderProps> = ({ pathway, currentNode }) => {
         </MuiThemeProvider>
 
         <div ref={graphContainerElement} className={styles.graph}>
+          <div className={styles.graphHeader}>
+            <div className={styles.graphHeaderText}>
+              <span>Criteria Builder</span>
+            </div>
+            <IconButton className={styles.toggleButton} onClick={handleToggle}>
+              <FontAwesomeIcon icon={toggle ? faToggleOn : faToggleOff} />
+            </IconButton>
+          </div>
           <Graph pathway={pathway} expandCurrentNode={true} currentNode={currentNode} />
         </div>
       </div>

--- a/src/components/Builder/Builder.tsx
+++ b/src/components/Builder/Builder.tsx
@@ -11,7 +11,7 @@ import { useTheme } from 'components/ThemeProvider';
 
 import { IconButton } from '@material-ui/core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faToggleOff, faToggleOn } from '@fortawesome/free-solid-svg-icons';
+import { faProjectDiagram } from '@fortawesome/free-solid-svg-icons';
 import useStyles from './styles';
 
 interface BuilderProps {
@@ -57,8 +57,11 @@ const Builder: FC<BuilderProps> = ({ pathway, currentNode }) => {
                 <div className={styles.graphHeaderText}>
                   <span>Criteria Builder</span>
                 </div>
-                <IconButton className={styles.toggleButton} onClick={handleToggle}>
-                  <FontAwesomeIcon icon={criteriaBuilderToggle ? faToggleOn : faToggleOff} />
+                <IconButton
+                  className={`${styles.toggleButton}-${criteriaBuilderToggle ? 'on' : 'off'}`}
+                  onClick={handleToggle}
+                >
+                  <FontAwesomeIcon className={styles.toggleIcon} icon={faProjectDiagram} />
                 </IconButton>
               </>
             )}

--- a/src/components/Builder/Builder.tsx
+++ b/src/components/Builder/Builder.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useRef, useEffect, memo, useState, useCallback } from 'react';
 import { Pathway, State } from 'pathways-model';
 import { ThemeProvider as MuiThemeProvider } from '@material-ui/core/styles';
+import { useCriteriaContext } from 'components/CriteriaProvider';
 
 import Header from 'components/Header';
 import Navigation from 'components/Navigation';
@@ -20,14 +21,15 @@ interface BuilderProps {
 
 const Builder: FC<BuilderProps> = ({ pathway, currentNode }) => {
   const styles = useStyles();
+  const { buildCriteria } = useCriteriaContext();
   const headerElement = useRef<HTMLDivElement>(null);
   const graphContainerElement = useRef<HTMLDivElement>(null);
   const theme = useTheme('dark');
-  const [toggle, setToggle] = useState<boolean>(false);
+  const [criteriaBuilderToggle, setCriteriaBuilderToggle] = useState<boolean>(true);
 
   const handleToggle = useCallback((): void => {
-    setToggle(!toggle);
-  }, [toggle]);
+    setCriteriaBuilderToggle(!criteriaBuilderToggle);
+  }, [criteriaBuilderToggle]);
 
   // Set the height of the graph container
   useEffect(() => {
@@ -50,14 +52,23 @@ const Builder: FC<BuilderProps> = ({ pathway, currentNode }) => {
 
         <div ref={graphContainerElement} className={styles.graph}>
           <div className={styles.graphHeader}>
-            <div className={styles.graphHeaderText}>
-              <span>Criteria Builder</span>
-            </div>
-            <IconButton className={styles.toggleButton} onClick={handleToggle}>
-              <FontAwesomeIcon icon={toggle ? faToggleOn : faToggleOff} />
-            </IconButton>
+            {buildCriteria && (
+              <>
+                <div className={styles.graphHeaderText}>
+                  <span>Criteria Builder</span>
+                </div>
+                <IconButton className={styles.toggleButton} onClick={handleToggle}>
+                  <FontAwesomeIcon icon={criteriaBuilderToggle ? faToggleOn : faToggleOff} />
+                </IconButton>
+              </>
+            )}
           </div>
-          <Graph pathway={pathway} expandCurrentNode={true} currentNode={currentNode} />
+          {buildCriteria && criteriaBuilderToggle ? (
+            // Empty section for authoring tool
+            <div />
+          ) : (
+            <Graph pathway={pathway} expandCurrentNode={true} currentNode={currentNode} />
+          )}
         </div>
       </div>
     </>

--- a/src/components/Builder/styles.tsx
+++ b/src/components/Builder/styles.tsx
@@ -3,7 +3,7 @@ import { makeStyles, Theme as AugmentedTheme, darken } from '@material-ui/core/s
 const toggleButtonCss = {
   borderRadius: '0%',
   marginLeft: '1px',
-  width: '6%',
+  width: '50px',
   height: '50px'
 };
 
@@ -26,7 +26,7 @@ export default makeStyles(
     graphHeaderText: {
       height: '50px',
       display: 'flex',
-      width: '95%',
+      width: '100%',
       backgroundColor: theme.palette.primary.main,
       alignItems: 'center',
       color: theme.palette.common.white,

--- a/src/components/Builder/styles.tsx
+++ b/src/components/Builder/styles.tsx
@@ -1,5 +1,12 @@
 import { makeStyles, Theme as AugmentedTheme, darken } from '@material-ui/core/styles';
 
+const toggleButtonCss = {
+  borderRadius: '0%',
+  marginLeft: '1px',
+  width: '6%',
+  height: '50px'
+};
+
 export default makeStyles(
   (theme: AugmentedTheme) => ({
     display: {
@@ -27,14 +34,24 @@ export default makeStyles(
       paddingLeft: '1.5em'
     },
     toggleButton: {
-      borderRadius: '0%',
-      marginLeft: '1px',
-      width: '5%',
-      height: '50px',
-      backgroundColor: theme.palette.primary.main,
-      '&:hover': {
-        backgroundColor: darken(theme.palette.primary.main, 0.1)
+      '&-on': {
+        ...toggleButtonCss,
+        backgroundColor: theme.palette.primary.main,
+        '&:hover': {
+          backgroundColor: darken(theme.palette.primary.main, 0.1)
+        }
+      },
+      '&-off': {
+        ...toggleButtonCss,
+        backgroundColor: theme.palette.text.primary,
+        '&:hover': {
+          backgroundColor: darken(theme.palette.text.primary, 0.1)
+        }
       }
+    },
+    toggleIcon: {
+      transform: 'rotate(90deg) scaleY(-1)',
+      color: theme.palette.common.white
     }
   }),
   { name: 'Builder' }

--- a/src/components/Builder/styles.tsx
+++ b/src/components/Builder/styles.tsx
@@ -1,0 +1,41 @@
+import { makeStyles, Theme as AugmentedTheme, darken } from '@material-ui/core/styles';
+
+export default makeStyles(
+  (theme: AugmentedTheme) => ({
+    display: {
+      display: 'flex'
+    },
+    graph: {
+      width: '100%',
+      height: '100%',
+      'overflow-y': 'scroll'
+    },
+    graphHeader: {
+      display: 'flex',
+      height: '50px',
+      backgroundColor: theme.palette.common.white,
+      marginLeft: '1px'
+    },
+    graphHeaderText: {
+      height: '50px',
+      display: 'flex',
+      width: '95%',
+      backgroundColor: theme.palette.primary.main,
+      alignItems: 'center',
+      color: theme.palette.common.white,
+      fontSize: '1.4em',
+      paddingLeft: '1.5em'
+    },
+    toggleButton: {
+      borderRadius: '0%',
+      marginLeft: '1px',
+      width: '5%',
+      height: '50px',
+      backgroundColor: theme.palette.primary.main,
+      '&:hover': {
+        backgroundColor: darken(theme.palette.primary.main, 0.1)
+      }
+    }
+  }),
+  { name: 'Builder' }
+);

--- a/src/components/CriteriaProvider.tsx
+++ b/src/components/CriteriaProvider.tsx
@@ -24,8 +24,10 @@ interface Criteria {
 
 interface CriteriaContextInterface {
   criteria: Criteria[];
+  buildCriteria: boolean;
   addCriteria: (file: File) => void;
   deleteCriteria: (id: string) => void;
+  toggleBuildCriteria: () => void;
 }
 
 export const CriteriaContext = createContext<CriteriaContextInterface>(
@@ -68,6 +70,7 @@ function jsonToCriteria(rawElm: string): Criteria | undefined {
 
 export const CriteriaProvider: FC<CriteriaProviderProps> = memo(({ children }) => {
   const [criteria, setCriteria] = useState<Criteria[]>([]);
+  const [buildCriteria, setBuildCriteria] = useState<boolean>(false);
   const service = useGetService<Criteria>(config.get('demoCriteria'));
   const payload = (service as ServiceLoaded<Criteria[]>).payload;
 
@@ -98,8 +101,14 @@ export const CriteriaProvider: FC<CriteriaProviderProps> = memo(({ children }) =
     setCriteria(currentCriteria => currentCriteria.filter(criteria => criteria.id !== id));
   }, []);
 
+  const toggleBuildCriteria = useCallback(() => {
+    setBuildCriteria(!buildCriteria);
+  }, [buildCriteria]);
+
   return (
-    <CriteriaContext.Provider value={{ criteria, addCriteria, deleteCriteria }}>
+    <CriteriaContext.Provider
+      value={{ criteria, buildCriteria, addCriteria, deleteCriteria, toggleBuildCriteria }}
+    >
       {children}
     </CriteriaContext.Provider>
   );

--- a/src/components/CriteriaProvider.tsx
+++ b/src/components/CriteriaProvider.tsx
@@ -24,10 +24,10 @@ interface Criteria {
 
 interface CriteriaContextInterface {
   criteria: Criteria[];
-  buildCriteria: boolean;
+  buildCriteriaNodeId: string;
   addCriteria: (file: File) => void;
   deleteCriteria: (id: string) => void;
-  toggleBuildCriteria: () => void;
+  updateBuildCriteriaNodeId: (id: string) => void;
 }
 
 export const CriteriaContext = createContext<CriteriaContextInterface>(
@@ -70,7 +70,7 @@ function jsonToCriteria(rawElm: string): Criteria | undefined {
 
 export const CriteriaProvider: FC<CriteriaProviderProps> = memo(({ children }) => {
   const [criteria, setCriteria] = useState<Criteria[]>([]);
-  const [buildCriteria, setBuildCriteria] = useState<boolean>(false);
+  const [buildCriteriaNodeId, setBuildCriteriaNodeId] = useState<string>('');
   const service = useGetService<Criteria>(config.get('demoCriteria'));
   const payload = (service as ServiceLoaded<Criteria[]>).payload;
 
@@ -101,13 +101,22 @@ export const CriteriaProvider: FC<CriteriaProviderProps> = memo(({ children }) =
     setCriteria(currentCriteria => currentCriteria.filter(criteria => criteria.id !== id));
   }, []);
 
-  const toggleBuildCriteria = useCallback(() => {
-    setBuildCriteria(!buildCriteria);
-  }, [buildCriteria]);
+  const updateBuildCriteriaNodeId = useCallback(
+    (id: string) => {
+      setBuildCriteriaNodeId(id);
+    },
+    [setBuildCriteriaNodeId]
+  );
 
   return (
     <CriteriaContext.Provider
-      value={{ criteria, buildCriteria, addCriteria, deleteCriteria, toggleBuildCriteria }}
+      value={{
+        criteria,
+        buildCriteriaNodeId,
+        addCriteria,
+        deleteCriteria,
+        updateBuildCriteriaNodeId
+      }}
     >
       {children}
     </CriteriaContext.Provider>

--- a/src/components/Graph/Graph.tsx
+++ b/src/components/Graph/Graph.tsx
@@ -132,13 +132,27 @@ const Graph: FC<GraphProps> = memo(
 
     // Recalculate graph layout if graph container size changes
     useEffect(() => {
+      // Keeps track of whether the current useEffect cycle has ended
+      let cancel = false;
+
       if (graphElement.current?.parentElement) {
         new ResizeSensor(graphElement.current.parentElement, function() {
+          if (!cancel) {
+            setParentWidth(graphElement.current?.parentElement?.clientWidth ?? 0);
+            setLayout(getGraphLayout());
+          }
+        });
+        const { clientWidth } = graphElement.current.parentElement;
+        if (clientWidth && parentWidth !== clientWidth) {
           setParentWidth(graphElement.current?.parentElement?.clientWidth ?? 0);
           setLayout(getGraphLayout());
-        });
+        }
       }
-    }, [getGraphLayout]);
+
+      return (): void => {
+        cancel = true;
+      };
+    }, [getGraphLayout, parentWidth]);
 
     // Recalculate graph layout if a node is expanded
     useEffect(() => {

--- a/src/components/Graph/Graph.tsx
+++ b/src/components/Graph/Graph.tsx
@@ -13,6 +13,7 @@ import { useParams, useHistory } from 'react-router-dom';
 import graphLayout from 'visualization/layout';
 import Node from 'components/Node';
 import Arrow from 'components/Arrow';
+import { useCriteriaContext } from 'components/CriteriaProvider';
 import { Pathway, State } from 'pathways-model';
 import { Layout, NodeDimensions, NodeCoordinates, Edges } from 'graph-model';
 import styles from './Graph.module.scss';
@@ -212,6 +213,7 @@ const GraphMemo: FC<GraphMemoProps> = memo(
   }) => {
     const { id: pathwayId } = useParams();
     const history = useHistory();
+    const { updateBuildCriteriaNodeId } = useCriteriaContext();
     const redirectToNode = useCallback(
       nodeId => {
         const url = `/builder/${encodeURIComponent(pathwayId)}/node/${encodeURIComponent(nodeId)}`;
@@ -226,9 +228,10 @@ const GraphMemo: FC<GraphMemoProps> = memo(
         if (interactive) {
           redirectToNode(nodeName);
           toggleExpanded(nodeName);
+          updateBuildCriteriaNodeId('');
         }
       },
-      [redirectToNode, toggleExpanded, interactive]
+      [redirectToNode, toggleExpanded, updateBuildCriteriaNodeId, interactive]
     );
     return (
       <div

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -5,12 +5,14 @@ import { faCog } from '@fortawesome/free-solid-svg-icons';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 
+import { useCriteriaContext } from 'components/CriteriaProvider';
 import { useThemeToggle } from '../ThemeProvider';
 
 import logo from 'camino-logo-dark.png';
 import styles from './Header.module.scss';
 
 const Header: FC = () => {
+  const { updateBuildCriteriaNodeId } = useCriteriaContext();
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const toggleTheme = useThemeToggle();
 
@@ -29,7 +31,7 @@ const Header: FC = () => {
 
   return (
     <header className={styles.header}>
-      <Link to="/" className={styles.homeLink}>
+      <Link to="/" className={styles.homeLink} onClick={(): void => updateBuildCriteriaNodeId('')}>
         <img src={logo} alt="logo" className={styles.logo} />
       </Link>
 

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -6,6 +6,7 @@ import { IconButton, Menu, MenuItem } from '@material-ui/core';
 
 import { Pathway } from 'pathways-model';
 import { downloadPathway } from 'utils/builder';
+import { useCriteriaContext } from 'components/CriteriaProvider';
 import useStyles from './styles';
 
 interface Props {
@@ -13,6 +14,7 @@ interface Props {
 }
 
 const Navigation: FC<Props> = ({ pathway }) => {
+  const { updateBuildCriteriaNodeId } = useCriteriaContext();
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const styles = useStyles();
   const history = useHistory();
@@ -26,8 +28,9 @@ const Navigation: FC<Props> = ({ pathway }) => {
   }, []);
 
   const handleGoBack = useCallback((): void => {
+    updateBuildCriteriaNodeId('');
     history.push('/');
-  }, [history]);
+  }, [history, updateBuildCriteriaNodeId]);
 
   return (
     <nav className={styles.root}>

--- a/src/components/Sidebar/BranchTransition.tsx
+++ b/src/components/Sidebar/BranchTransition.tsx
@@ -1,4 +1,4 @@
-import React, { FC, memo, useState, useCallback, ChangeEvent } from 'react';
+import React, { FC, memo, useState, useCallback, ChangeEvent, useEffect } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPlus, faSave, faTools, faTrashAlt } from '@fortawesome/free-solid-svg-icons';
 import DropDown from 'components/elements/DropDown';
@@ -22,7 +22,7 @@ interface BranchTransitionProps {
 
 const BranchTransition: FC<BranchTransitionProps> = ({ pathway, currentNodeKey, transition }) => {
   const { updatePathway } = usePathwayContext();
-  const { criteria, toggleBuildCriteria } = useCriteriaContext();
+  const { criteria, buildCriteriaNodeId, updateBuildCriteriaNodeId } = useCriteriaContext();
   const criteriaOptions = criteria.map(c => ({ value: c.id, label: c.label }));
   const styles = useStyles();
   const transitionKey = transition?.transition || '';
@@ -95,15 +95,22 @@ const BranchTransition: FC<BranchTransitionProps> = ({ pathway, currentNodeKey, 
   );
 
   const handleBuildCriteria = useCallback((): void => {
-    toggleBuildCriteria();
+    updateBuildCriteriaNodeId(transition.id ?? '');
     setBuildCriteriaSelected(!buildCriteriaSelected);
-  }, [buildCriteriaSelected, toggleBuildCriteria]);
+  }, [buildCriteriaSelected, updateBuildCriteriaNodeId, transition]);
 
   const handleBuildCriteriaCancel = useCallback((): void => {
-    toggleBuildCriteria();
-    setBuildCriteriaSelected(!buildCriteriaSelected);
+    if (buildCriteriaNodeId === transition.id) updateBuildCriteriaNodeId('');
+    setBuildCriteriaSelected(false);
     setCriteriaName('');
-  }, [toggleBuildCriteria, setCriteriaName, buildCriteriaSelected]);
+  }, [updateBuildCriteriaNodeId, setCriteriaName, buildCriteriaNodeId, transition]);
+
+  // Cancel current build criteria if clicked on another BranchTransition
+  useEffect(() => {
+    if (buildCriteriaNodeId !== '' && buildCriteriaNodeId !== transition.id) {
+      handleBuildCriteriaCancel();
+    }
+  }, [buildCriteriaNodeId, handleBuildCriteriaCancel, transition]);
 
   return (
     <>

--- a/src/components/Sidebar/BranchTransition.tsx
+++ b/src/components/Sidebar/BranchTransition.tsx
@@ -2,7 +2,7 @@ import React, { FC, memo, useState, useCallback, ChangeEvent } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPlus, faSave, faTools, faTrashAlt } from '@fortawesome/free-solid-svg-icons';
 import DropDown from 'components/elements/DropDown';
-import { Button, Checkbox, FormControlLabel, TextField } from '@material-ui/core';
+import { Button, Checkbox, FormControlLabel, TextField, Box } from '@material-ui/core';
 import {
   removeTransitionCondition,
   setTransitionCondition,
@@ -162,10 +162,11 @@ const BranchTransition: FC<BranchTransitionProps> = ({ pathway, currentNodeKey, 
             label="Criteria Name"
             variant="outlined"
             onChange={handleCriteriaName}
+            fullWidth
           />
           <div>
             <FormControlLabel
-              label="Add to reusable criteria"
+              label={<Box fontStyle="italic">Add to reusable criteria</Box>}
               control={<Checkbox color="default" />}
             />
             <Button color="inherit" size="large" variant="outlined">

--- a/src/components/Sidebar/BranchTransition.tsx
+++ b/src/components/Sidebar/BranchTransition.tsx
@@ -98,6 +98,11 @@ const BranchTransition: FC<BranchTransitionProps> = ({ pathway, currentNodeKey, 
     [setCriteriaName]
   );
 
+  const handleBuildCriteriaCancel = useCallback((): void => {
+    setBuildCriteriaSelected(false);
+    setCriteriaName('');
+  }, [setBuildCriteriaSelected, setCriteriaName]);
+
   return (
     <>
       <hr className={styles.divider} />
@@ -169,7 +174,12 @@ const BranchTransition: FC<BranchTransitionProps> = ({ pathway, currentNodeKey, 
               label={<Box fontStyle="italic">Add to reusable criteria</Box>}
               control={<Checkbox color="default" />}
             />
-            <Button color="inherit" size="large" variant="outlined">
+            <Button
+              color="inherit"
+              size="large"
+              variant="outlined"
+              onClick={handleBuildCriteriaCancel}
+            >
               Cancel
             </Button>
             <Button

--- a/src/components/Sidebar/BranchTransition.tsx
+++ b/src/components/Sidebar/BranchTransition.tsx
@@ -37,6 +37,7 @@ const BranchTransition: FC<BranchTransitionProps> = ({ pathway, currentNodeKey, 
   const icon = hasCriteria ? <FontAwesomeIcon icon={faTrashAlt} /> : null;
   const displayCriteria =
     useCriteriaSelected || transition.condition?.cql || transition.condition?.description;
+  const [buildCriteriaSelected, setBuildCriteriaSelected] = useState<boolean>(false);
 
   const handleUseCriteria = useCallback((): void => {
     if (hasCriteria && transition.id) {
@@ -47,6 +48,10 @@ const BranchTransition: FC<BranchTransitionProps> = ({ pathway, currentNodeKey, 
       setUseCriteriaSelected(!useCriteriaSelected);
     }
   }, [useCriteriaSelected, currentNodeKey, pathway, hasCriteria, transition.id, updatePathway]);
+
+  const handleBuildCriteria = useCallback((): void => {
+    setBuildCriteriaSelected(!buildCriteriaSelected);
+  }, [buildCriteriaSelected]);
 
   const selectCriteriaSource = useCallback(
     (event: ChangeEvent<{ value: string }>): void => {
@@ -92,7 +97,7 @@ const BranchTransition: FC<BranchTransitionProps> = ({ pathway, currentNodeKey, 
 
       <SidebarHeader pathway={pathway} currentNode={transitionNode} isTransition={true} />
 
-      {!displayCriteria && (
+      {!displayCriteria && !buildCriteriaSelected && (
         <SidebarButton
           buttonName="Use Criteria"
           buttonIcon={<FontAwesomeIcon icon={faPlus} />}
@@ -134,11 +139,12 @@ const BranchTransition: FC<BranchTransitionProps> = ({ pathway, currentNodeKey, 
         </OutlinedDiv>
       )}
 
-      {!displayCriteria && (
+      {!displayCriteria && !buildCriteriaSelected && (
         <SidebarButton
           buttonName="Build Criteria"
           buttonIcon={<FontAwesomeIcon icon={faTools} />}
           buttonText="Create new criteria logic to add to branch node."
+          onClick={handleBuildCriteria}
         />
       )}
     </>

--- a/src/components/Sidebar/BranchTransition.tsx
+++ b/src/components/Sidebar/BranchTransition.tsx
@@ -22,7 +22,7 @@ interface BranchTransitionProps {
 
 const BranchTransition: FC<BranchTransitionProps> = ({ pathway, currentNodeKey, transition }) => {
   const { updatePathway } = usePathwayContext();
-  const { criteria, buildCriteria, toggleBuildCriteria } = useCriteriaContext();
+  const { criteria, toggleBuildCriteria } = useCriteriaContext();
   const criteriaOptions = criteria.map(c => ({ value: c.id, label: c.label }));
   const styles = useStyles();
   const transitionKey = transition?.transition || '';
@@ -94,10 +94,16 @@ const BranchTransition: FC<BranchTransitionProps> = ({ pathway, currentNodeKey, 
     [setCriteriaName]
   );
 
+  const handleBuildCriteria = useCallback((): void => {
+    toggleBuildCriteria();
+    setBuildCriteriaSelected(!buildCriteriaSelected);
+  }, [buildCriteriaSelected, toggleBuildCriteria]);
+
   const handleBuildCriteriaCancel = useCallback((): void => {
     toggleBuildCriteria();
+    setBuildCriteriaSelected(!buildCriteriaSelected);
     setCriteriaName('');
-  }, [toggleBuildCriteria, setCriteriaName]);
+  }, [toggleBuildCriteria, setCriteriaName, buildCriteriaSelected]);
 
   return (
     <>
@@ -152,11 +158,11 @@ const BranchTransition: FC<BranchTransitionProps> = ({ pathway, currentNodeKey, 
           buttonName="Build Criteria"
           buttonIcon={<FontAwesomeIcon icon={faTools} />}
           buttonText="Create new criteria logic to add to branch node."
-          onClick={toggleBuildCriteria}
+          onClick={handleBuildCriteria}
         />
       )}
 
-      {buildCriteria && (
+      {buildCriteriaSelected && (
         <OutlinedDiv label="Criteria Builder" error={criteriaName === ''}>
           <TextField
             error={criteriaName === ''}

--- a/src/components/Sidebar/BranchTransition.tsx
+++ b/src/components/Sidebar/BranchTransition.tsx
@@ -1,4 +1,4 @@
-import React, { FC, memo, useState, useCallback, ChangeEvent } from 'react';
+import React, { FC, memo, useRef, useState, useCallback, ChangeEvent } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPlus, faTools, faTrashAlt } from '@fortawesome/free-solid-svg-icons';
 import { TextField, Button } from '@material-ui/core';
@@ -38,6 +38,7 @@ const BranchTransition: FC<BranchTransitionProps> = ({ pathway, currentNodeKey, 
   const displayCriteria =
     useCriteriaSelected || transition.condition?.cql || transition.condition?.description;
   const [buildCriteriaSelected, setBuildCriteriaSelected] = useState<boolean>(false);
+  const criteriaNameRef = useRef<HTMLInputElement>(null);
 
   const handleUseCriteria = useCallback((): void => {
     if (hasCriteria && transition.id) {
@@ -146,6 +147,12 @@ const BranchTransition: FC<BranchTransitionProps> = ({ pathway, currentNodeKey, 
           buttonText="Create new criteria logic to add to branch node."
           onClick={handleBuildCriteria}
         />
+      )}
+
+      {buildCriteriaSelected && (
+        <OutlinedDiv label="Criteria Builder" error={true}>
+          <TextField label="Criteria Name" variant="outlined" inputRef={criteriaNameRef} />
+        </OutlinedDiv>
       )}
     </>
   );

--- a/src/components/Sidebar/BranchTransition.tsx
+++ b/src/components/Sidebar/BranchTransition.tsx
@@ -163,7 +163,7 @@ const BranchTransition: FC<BranchTransitionProps> = ({ pathway, currentNodeKey, 
       )}
 
       {buildCriteriaSelected && (
-        <OutlinedDiv label="Criteria Builder" error={criteriaName === ''}>
+        <OutlinedDiv label="Criteria Builder" error={true}>
           <TextField
             error={criteriaName === ''}
             label="Criteria Name"

--- a/src/components/Sidebar/BranchTransition.tsx
+++ b/src/components/Sidebar/BranchTransition.tsx
@@ -22,7 +22,7 @@ interface BranchTransitionProps {
 
 const BranchTransition: FC<BranchTransitionProps> = ({ pathway, currentNodeKey, transition }) => {
   const { updatePathway } = usePathwayContext();
-  const { criteria } = useCriteriaContext();
+  const { criteria, buildCriteria, toggleBuildCriteria } = useCriteriaContext();
   const criteriaOptions = criteria.map(c => ({ value: c.id, label: c.label }));
   const styles = useStyles();
   const transitionKey = transition?.transition || '';
@@ -48,10 +48,6 @@ const BranchTransition: FC<BranchTransitionProps> = ({ pathway, currentNodeKey, 
       setUseCriteriaSelected(!useCriteriaSelected);
     }
   }, [useCriteriaSelected, currentNodeKey, pathway, hasCriteria, transition.id, updatePathway]);
-
-  const handleBuildCriteria = useCallback((): void => {
-    setBuildCriteriaSelected(!buildCriteriaSelected);
-  }, [buildCriteriaSelected]);
 
   const selectCriteriaSource = useCallback(
     (event: ChangeEvent<{ value: string }>): void => {
@@ -99,9 +95,9 @@ const BranchTransition: FC<BranchTransitionProps> = ({ pathway, currentNodeKey, 
   );
 
   const handleBuildCriteriaCancel = useCallback((): void => {
-    setBuildCriteriaSelected(false);
+    toggleBuildCriteria();
     setCriteriaName('');
-  }, [setBuildCriteriaSelected, setCriteriaName]);
+  }, [toggleBuildCriteria, setCriteriaName]);
 
   return (
     <>
@@ -156,11 +152,11 @@ const BranchTransition: FC<BranchTransitionProps> = ({ pathway, currentNodeKey, 
           buttonName="Build Criteria"
           buttonIcon={<FontAwesomeIcon icon={faTools} />}
           buttonText="Create new criteria logic to add to branch node."
-          onClick={handleBuildCriteria}
+          onClick={toggleBuildCriteria}
         />
       )}
 
-      {buildCriteriaSelected && (
+      {buildCriteria && (
         <OutlinedDiv label="Criteria Builder" error={criteriaName === ''}>
           <TextField
             error={criteriaName === ''}

--- a/src/components/Sidebar/BranchTransition.tsx
+++ b/src/components/Sidebar/BranchTransition.tsx
@@ -178,7 +178,7 @@ const BranchTransition: FC<BranchTransitionProps> = ({ pathway, currentNodeKey, 
             onChange={handleCriteriaName}
             fullWidth
           />
-          <div>
+          <div className={styles.buildCriteriaContainer}>
             <FormControlLabel
               label={<Box fontStyle="italic">Add to reusable criteria</Box>}
               control={<Checkbox color="default" />}

--- a/src/components/Sidebar/BranchTransition.tsx
+++ b/src/components/Sidebar/BranchTransition.tsx
@@ -1,17 +1,16 @@
-import React, { FC, memo, useRef, useState, useCallback, ChangeEvent } from 'react';
+import React, { FC, memo, useState, useCallback, ChangeEvent } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faPlus, faTools, faTrashAlt } from '@fortawesome/free-solid-svg-icons';
-import { TextField, Button } from '@material-ui/core';
-
+import { faPlus, faSave, faTools, faTrashAlt } from '@fortawesome/free-solid-svg-icons';
 import DropDown from 'components/elements/DropDown';
-import { SidebarHeader, SidebarButton, OutlinedDiv } from '.';
+import { Button, Checkbox, FormControlLabel, TextField } from '@material-ui/core';
+import {
+  removeTransitionCondition,
+  setTransitionCondition,
+  setTransitionConditionDescription
+} from 'utils/builder';
+import { OutlinedDiv, SidebarHeader, SidebarButton } from '.';
 import { Pathway, Transition } from 'pathways-model';
 import { useCriteriaContext } from 'components/CriteriaProvider';
-import {
-  setTransitionCondition,
-  setTransitionConditionDescription,
-  removeTransitionCondition
-} from 'utils/builder';
 import { usePathwayContext } from 'components/PathwayProvider';
 import useStyles from './styles';
 
@@ -38,7 +37,7 @@ const BranchTransition: FC<BranchTransitionProps> = ({ pathway, currentNodeKey, 
   const displayCriteria =
     useCriteriaSelected || transition.condition?.cql || transition.condition?.description;
   const [buildCriteriaSelected, setBuildCriteriaSelected] = useState<boolean>(false);
-  const criteriaNameRef = useRef<HTMLInputElement>(null);
+  const [criteriaName, setCriteriaName] = useState<string>('');
 
   const handleUseCriteria = useCallback((): void => {
     if (hasCriteria && transition.id) {
@@ -90,6 +89,13 @@ const BranchTransition: FC<BranchTransitionProps> = ({ pathway, currentNodeKey, 
       );
     },
     [currentNodeKey, transition.id, updatePathway, pathway]
+  );
+
+  const handleCriteriaName = useCallback(
+    (event: ChangeEvent<{ value: string }>): void => {
+      setCriteriaName(event?.target.value || '');
+    },
+    [setCriteriaName]
   );
 
   return (
@@ -150,11 +156,36 @@ const BranchTransition: FC<BranchTransitionProps> = ({ pathway, currentNodeKey, 
       )}
 
       {buildCriteriaSelected && (
-        <OutlinedDiv label="Criteria Builder" error={true}>
-          <TextField label="Criteria Name" variant="outlined" inputRef={criteriaNameRef} />
+        <OutlinedDiv label="Criteria Builder" error={criteriaName === ''}>
+          <TextField
+            error={criteriaName === ''}
+            label="Criteria Name"
+            variant="outlined"
+            onChange={handleCriteriaName}
+          />
+          <div>
+            <FormControlLabel
+              label="Add to reusable criteria"
+              control={<Checkbox color="default" />}
+            />
+            <Button color="inherit" size="large" variant="outlined">
+              Cancel
+            </Button>
+            <Button
+              className={styles.saveButton}
+              color="inherit"
+              size="large"
+              variant="outlined"
+              startIcon={<FontAwesomeIcon icon={faSave} />}
+              disabled
+            >
+              Save
+            </Button>
+          </div>
         </OutlinedDiv>
       )}
     </>
   );
 };
+
 export default memo(BranchTransition);

--- a/src/components/Sidebar/OutlinedDiv.tsx
+++ b/src/components/Sidebar/OutlinedDiv.tsx
@@ -34,9 +34,7 @@ const OutlinedDiv: FC<OutlinedDivProps> = ({ children, label, error }) => {
           notchedOutline: clsx(error && styles.outlinedDivError)
         }
       }}
-      inputProps={{
-        children: children
-      }}
+      inputProps={{ children }}
     />
   );
 };

--- a/src/components/Sidebar/styles.tsx
+++ b/src/components/Sidebar/styles.tsx
@@ -71,6 +71,20 @@ export default makeStyles(
     sidebarButtonText: {
       fontStyle: 'italic'
     },
+    outlinedDiv: {
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'flex-start',
+      '& div': {
+        width: '100%'
+      }
+    },
+    outlinedDivError: {
+      borderColor: `${theme.palette.error.main} !important`,
+      '&:hover': {
+        borderColor: `${theme.palette.error.main} !important`
+      }
+    },
     toggleSidebar: {
       display: 'inline-flex',
       alignItems: 'center',

--- a/src/components/Sidebar/styles.tsx
+++ b/src/components/Sidebar/styles.tsx
@@ -120,6 +120,10 @@ export default makeStyles(
         borderColor: `${theme.palette.error.main} !important`
       }
     },
+    buildCriteriaContainer: {
+      display: 'flex',
+      justifyContent: 'space-between'
+    },
     saveButton: {
       marginLeft: '1em'
     }

--- a/src/components/Sidebar/styles.tsx
+++ b/src/components/Sidebar/styles.tsx
@@ -106,20 +106,6 @@ export default makeStyles(
       padding: '5px 15px',
       fontSize: '1em'
     },
-    outlinedDiv: {
-      display: 'flex',
-      flexDirection: 'column',
-      alignItems: 'flex-start',
-      '& div': {
-        width: '100%'
-      }
-    },
-    outlinedDivError: {
-      borderColor: `${theme.palette.error.main} !important`,
-      '&:hover': {
-        borderColor: `${theme.palette.error.main} !important`
-      }
-    },
     buildCriteriaContainer: {
       display: 'flex',
       justifyContent: 'space-between'

--- a/src/components/Sidebar/styles.tsx
+++ b/src/components/Sidebar/styles.tsx
@@ -105,6 +105,9 @@ export default makeStyles(
       '&:hover': {
         borderColor: `${theme.palette.error.main} !important`
       }
+    },
+    saveButton: {
+      marginLeft: '1em'
     }
   }),
   { name: 'Sidebar' }

--- a/src/styles/theme.tsx
+++ b/src/styles/theme.tsx
@@ -58,7 +58,11 @@ const typography = {
 const materialUiOverridesBase = {
   MuiButton: {
     root: {
-      borderRadius: 0
+      borderRadius: 0,
+      '&.Mui-disabled': {
+        backgroundColor: colors.grayMedium,
+        color: colors.white
+      }
     },
     label: {
       fontWeight: 600


### PR DESCRIPTION
Clicking on the "Build Criteria" button results in popping up:
![image](https://user-images.githubusercontent.com/6588796/86798439-c727c880-c03e-11ea-89bc-9fa3bfe07b3d.png)

- The save button is disabled for now until we hook up the authoring tool.
- Criteria Builder header and toggle button are also implemented.
![image](https://user-images.githubusercontent.com/6588796/86798618-f8a09400-c03e-11ea-8a8a-dcc17199978c.png)
- Currently there is a blank space left for the authoring tool. Clicking on the toggle button will bring the pathway view back up.
- Added `buildCriteria` to `CriteriaProvider` so `Builder` can know when to display the Criteria Builder header and toggle button.