### PR TITLE
increase style priority

### DIFF
--- a/src/components/Arrow/styles.tsx
+++ b/src/components/Arrow/styles.tsx
@@ -27,5 +27,5 @@ export default makeStyles(
       }
     }
   }),
-  { name: 'Arrow' }
+  { name: 'Arrow', index: 1 }
 );

--- a/src/components/Builder/styles.tsx
+++ b/src/components/Builder/styles.tsx
@@ -54,5 +54,5 @@ export default makeStyles(
       color: theme.palette.common.white
     }
   }),
-  { name: 'Builder' }
+  { name: 'Builder', index: 1 }
 );

--- a/src/components/CriteriaList/styles.tsx
+++ b/src/components/CriteriaList/styles.tsx
@@ -40,5 +40,5 @@ export default makeStyles(
       fontStyle: 'italic'
     }
   }),
-  { name: 'CriteriaList' }
+  { name: 'CriteriaList', index: 1 }
 );

--- a/src/components/Navigation/styles.tsx
+++ b/src/components/Navigation/styles.tsx
@@ -25,5 +25,5 @@ export default makeStyles(
       marginLeft: '1.5em'
     }
   }),
-  { name: 'Navigation' }
+  { name: 'Navigation', index: 1 }
 );

--- a/src/components/PathwaysList/styles.tsx
+++ b/src/components/PathwaysList/styles.tsx
@@ -21,5 +21,5 @@ export default makeStyles(
       width: '45px'
     }
   }),
-  { name: 'PathwaysList' }
+  { name: 'PathwaysList', index: 1 }
 );

--- a/src/components/Sidebar/styles.tsx
+++ b/src/components/Sidebar/styles.tsx
@@ -114,5 +114,5 @@ export default makeStyles(
       marginLeft: '1em'
     }
   }),
-  { name: 'Sidebar' }
+  { name: 'Sidebar', index: 1 }
 );

--- a/src/components/Tabs/styles.tsx
+++ b/src/components/Tabs/styles.tsx
@@ -13,5 +13,5 @@ export default makeStyles(
       fontWeight: 100
     }
   }),
-  { name: 'Tabs' }
+  { name: 'Tabs', index: 1 }
 );


### PR DESCRIPTION
Basically there's a discrepancy between the dev and production build, where the custom CSS we wrote would be injected after the CSS for material UI.  This meant that for some components, our styles got overridden.

I fixed this by using the "index" property of the options for `makeStyles` to increase the priority of our css over that of material-ui, so it renders correctly on production builds.  There are other ways to solve this problem that involve forcing our CSS to inject before the material UI CSS, but they are a bit more complicated and require some more changes.  I went ahead and added an index to every style file, so that this problem does not happen in the future.  

You can see that this works by visiting my fork of the project [here](https://github.com/KeeyanGhoreshi/pathway-builder/tree/gh-pages).  The buttons looked like this:

<img width="460" alt="Screen Shot 2020-06-24 at 10 05 23 AM" src="https://user-images.githubusercontent.com/24882348/87339727-09f11100-c515-11ea-91f4-3d0dc5b10c65.png">

But have been fixed on my forked version by changing the index.