### PR TITLE
Fix Graph Labels

### DIFF
--- a/src/components/Arrow/Arrow.tsx
+++ b/src/components/Arrow/Arrow.tsx
@@ -5,6 +5,7 @@ import { isBranchNode } from 'utils/nodeUtils';
 import useStyles from './styles';
 import clsx from 'clsx';
 import { Tooltip } from '@material-ui/core';
+import { withStyles } from '@material-ui/core/styles';
 
 interface ArrowProps {
   edge: Edge;
@@ -25,17 +26,23 @@ const Arrow: FC<ArrowProps> = ({ edge, edgeName, widthOffset, currentNode }) => 
   const edgeNameNoWhitespace = edgeName.replace(' ', '');
   const arrowheadId = `arrowhead-${edgeNameNoWhitespace}`;
 
+  const CustomTooltip = withStyles({
+    tooltip: {
+      fontSize: 14
+    }
+  })(Tooltip);
+
   const { label } = edge;
   return (
     <svg className={clsx(styles.arrow, isCurrentBranchArrow && styles.currentBranchArrow)}>
       <ArrowPath points={edge.points} arrowheadId={arrowheadId} widthOffset={widthOffset} />
       {label ? (
         label.text.length > 12 ? (
-          <Tooltip title={label.text} aria-label="tooltip">
+          <CustomTooltip title={label.text} aria-label="tooltip">
             <text x={label.x + widthOffset} y={label.y}>
               {label.text.substring(0, 11) + '...'}
             </text>
-          </Tooltip>
+          </CustomTooltip>
         ) : (
           <text x={label.x + widthOffset} y={label.y}>
             {label.text}

--- a/src/components/Arrow/Arrow.tsx
+++ b/src/components/Arrow/Arrow.tsx
@@ -4,7 +4,7 @@ import { PathwayNode } from 'pathways-model';
 import { isBranchNode } from 'utils/nodeUtils';
 import useStyles from './styles';
 import clsx from 'clsx';
-import { CustomTooltip } from 'styles/theme';
+import { Tooltip } from '@material-ui/core';
 
 interface ArrowProps {
   edge: Edge;
@@ -31,11 +31,11 @@ const Arrow: FC<ArrowProps> = ({ edge, edgeName, widthOffset, currentNode }) => 
       <ArrowPath points={edge.points} arrowheadId={arrowheadId} widthOffset={widthOffset} />
       {label ? (
         label.text.length > 12 ? (
-          <CustomTooltip title={label.text} aria-label="tooltip">
+          <Tooltip title={label.text} aria-label="tooltip">
             <text x={label.x + widthOffset} y={label.y}>
               {label.text.substring(0, 11) + '...'}
             </text>
-          </CustomTooltip>
+          </Tooltip>
         ) : (
           <text x={label.x + widthOffset} y={label.y}>
             {label.text}

--- a/src/components/Arrow/Arrow.tsx
+++ b/src/components/Arrow/Arrow.tsx
@@ -4,8 +4,7 @@ import { PathwayNode } from 'pathways-model';
 import { isBranchNode } from 'utils/nodeUtils';
 import useStyles from './styles';
 import clsx from 'clsx';
-import { Tooltip } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { CustomTooltip } from 'styles/theme';
 
 interface ArrowProps {
   edge: Edge;
@@ -25,12 +24,6 @@ const Arrow: FC<ArrowProps> = ({ edge, edgeName, widthOffset, currentNode }) => 
   const isCurrentBranchArrow = isBranchNode(currentNode) && edge.start === currentNode.key;
   const edgeNameNoWhitespace = edgeName.replace(' ', '');
   const arrowheadId = `arrowhead-${edgeNameNoWhitespace}`;
-
-  const CustomTooltip = withStyles({
-    tooltip: {
-      fontSize: 14
-    }
-  })(Tooltip);
 
   const { label } = edge;
   return (

--- a/src/components/Arrow/Arrow.tsx
+++ b/src/components/Arrow/Arrow.tsx
@@ -30,7 +30,7 @@ const Arrow: FC<ArrowProps> = ({ edge, edgeName, widthOffset, currentNode }) => 
       <ArrowPath points={edge.points} arrowheadId={arrowheadId} widthOffset={widthOffset} />
       {label ? (
         <text x={label.x + widthOffset} y={label.y}>
-          {label.text}
+          {label.text.length > 12 ? label.text.substring(0, 11) + '...' : label.text}
         </text>
       ) : null}
       <defs>

--- a/src/components/Arrow/Arrow.tsx
+++ b/src/components/Arrow/Arrow.tsx
@@ -4,6 +4,7 @@ import { PathwayNode } from 'pathways-model';
 import { isBranchNode } from 'utils/nodeUtils';
 import useStyles from './styles';
 import clsx from 'clsx';
+import { Tooltip } from '@material-ui/core';
 
 interface ArrowProps {
   edge: Edge;
@@ -29,9 +30,17 @@ const Arrow: FC<ArrowProps> = ({ edge, edgeName, widthOffset, currentNode }) => 
     <svg className={clsx(styles.arrow, isCurrentBranchArrow && styles.currentBranchArrow)}>
       <ArrowPath points={edge.points} arrowheadId={arrowheadId} widthOffset={widthOffset} />
       {label ? (
-        <text x={label.x + widthOffset} y={label.y}>
-          {label.text.length > 12 ? label.text.substring(0, 11) + '...' : label.text}
-        </text>
+        label.text.length > 12 ? (
+          <Tooltip title={label.text} aria-label="tooltip">
+            <text x={label.x + widthOffset} y={label.y}>
+              {label.text.substring(0, 11) + '...'}
+            </text>
+          </Tooltip>
+        ) : (
+          <text x={label.x + widthOffset} y={label.y}>
+            {label.text}
+          </text>
+        )
       ) : null}
       <defs>
         <marker

--- a/src/components/Graph/Graph.tsx
+++ b/src/components/Graph/Graph.tsx
@@ -230,7 +230,7 @@ const GraphMemo: FC<GraphMemoProps> = memo(function GraphMemo({
       <svg
         xmlns="http://www.w3.org/2000/svg"
         style={{
-          width: maxWidth,
+          width: maxWidth + 100,
           height: maxHeight,
           zIndex: 1,
           top: 0,

--- a/src/styles/theme.tsx
+++ b/src/styles/theme.tsx
@@ -1,7 +1,5 @@
 import { createMuiTheme } from '@material-ui/core/styles';
 import deepmerge from 'deepmerge';
-import { Tooltip } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
 
 declare module '@material-ui/core/styles/createMuiTheme' {
   interface Theme {
@@ -122,6 +120,11 @@ const materialUiOverridesBase = {
       }
     }
   },
+  MuiTooltip: {
+    tooltip: {
+      fontSize: 14
+    }
+  },
   MuiOutlinedInput: {
     root: {
       borderRadius: '0'
@@ -177,6 +180,11 @@ const materialUiOverridesDark = {
         borderColor: colors.white,
         backgroundColor: colors.grayDark
       }
+    }
+  },
+  MuiTooltip: {
+    tooltip: {
+      fontSize: 14
     }
   },
   MuiOutlinedInput: {
@@ -264,11 +272,5 @@ const projectorTheme = createMuiTheme({
   variables: { ...variables }
 });
 
-const CustomTooltip = withStyles({
-  tooltip: {
-    fontSize: 14
-  }
-})(Tooltip);
-
 export default lightTheme;
-export { lightTheme, darkTheme, projectorTheme, CustomTooltip };
+export { lightTheme, darkTheme, projectorTheme };

--- a/src/styles/theme.tsx
+++ b/src/styles/theme.tsx
@@ -1,5 +1,7 @@
 import { createMuiTheme } from '@material-ui/core/styles';
 import deepmerge from 'deepmerge';
+import { Tooltip } from '@material-ui/core';
+import { withStyles } from '@material-ui/core/styles';
 
 declare module '@material-ui/core/styles/createMuiTheme' {
   interface Theme {
@@ -262,5 +264,11 @@ const projectorTheme = createMuiTheme({
   variables: { ...variables }
 });
 
+const CustomTooltip = withStyles({
+  tooltip: {
+    fontSize: 14
+  }
+})(Tooltip);
+
 export default lightTheme;
-export { lightTheme, darkTheme, projectorTheme };
+export { lightTheme, darkTheme, projectorTheme, CustomTooltip };


### PR DESCRIPTION
This is to fix two issues with displaying the label on the arrows in the graph:
- The label of the arrow going to the furthest right node was being truncated after a few characters
- Labels could overlap if they were especially long