### PR TITLE
Multiple Transitions + Minor Updates

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,7 @@
     <title>Camino Builder</title>
     <link rel="icon" href="camino-icon.png" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/semantic-ui/dist/semantic.min.css" />
+    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,600;0,700;0,800;1,300;1,400;1,600;1,700;1,800&display=swap" rel="stylesheet">
     <script src="config.js" language="javascript"></script>
   </head>
   <body>

--- a/src/components/Navigation/styles.tsx
+++ b/src/components/Navigation/styles.tsx
@@ -17,7 +17,7 @@ export default makeStyles(
     },
     navigationIcons: {
       fontSize: '20px',
-      color: theme.palette.grey['800'],
+      color: theme.palette.common.gray,
       cursor: 'pointer'
     },
     pathwayName: {

--- a/src/components/Sidebar/ActionNodeEditor.tsx
+++ b/src/components/Sidebar/ActionNodeEditor.tsx
@@ -12,7 +12,6 @@ import DropDown from 'components/elements/DropDown';
 import { ActionNode, Action } from 'pathways-model';
 import { ElmLibrary } from 'elm-model';
 import useStyles from './styles';
-import shortid from 'shortid';
 import { TextField } from '@material-ui/core';
 import { convertBasicCQL } from 'engine/cql-to-elm';
 import { usePathwaysContext } from 'components/PathwaysProvider';
@@ -21,14 +20,10 @@ import produce from 'immer';
 import { useCurrentNodeContext } from 'components/CurrentNodeProvider';
 
 const nodeTypeOptions = [
-  { label: 'Action', value: 'action' },
-  { label: 'Branch', value: 'branch' }
-];
-
-const actionTypeOptions = [
   { label: 'Medication', value: 'MedicationRequest' },
   { label: 'Procedure', value: 'ServiceRequest' },
-  { label: 'Regimen', value: 'CarePlan' }
+  { label: 'Regimen', value: 'CarePlan' },
+  { label: 'Observation', value: 'Observation' }
 ];
 
 const codeSystemOptions = [
@@ -129,67 +124,6 @@ const ActionNodeEditor: FC<ActionNodeEditorProps> = ({ changeNodeType }) => {
     [currentNodeRef, pathwayRef, updatePathway, addActionCQL]
   );
 
-  const selectActionType = useCallback(
-    (event: ChangeEvent<{ value: string }>): void => {
-      if (!currentNodeRef.current?.key || !pathwayRef.current) return;
-      const value = event?.target.value || '';
-      const actionType = actionTypeOptions.find(option => {
-        return option.value === value;
-      });
-      let action: Action;
-      if (actionType?.value === 'CarePlan') {
-        action = {
-          type: 'create',
-          description: '',
-          id: shortid.generate(),
-          resource: {
-            resourceType: actionType?.value,
-            title: ''
-          }
-        };
-      } else if (actionType?.value === 'MedicationRequest') {
-        action = {
-          type: 'create',
-          description: '',
-          id: shortid.generate(),
-          resource: {
-            resourceType: actionType?.value,
-            medicationCodeableConcept: {
-              coding: [
-                {
-                  system: '',
-                  code: '',
-                  display: ''
-                }
-              ]
-            }
-          }
-        };
-      } else {
-        action = {
-          type: 'create',
-          description: '',
-          id: shortid.generate(),
-          resource: {
-            resourceType: actionType?.value,
-            code: {
-              coding: [
-                {
-                  system: '',
-                  code: '',
-                  display: ''
-                }
-              ]
-            }
-          }
-        };
-      }
-
-      updatePathway(setNodeAction(pathwayRef.current, currentNodeRef.current.key, [action]));
-    },
-    [currentNodeRef, pathwayRef, updatePathway]
-  );
-
   const selectCodeSystem = useCallback(
     (event: ChangeEvent<{ value: string }>): void => {
       if (!currentNodeRef.current?.key || !pathwayRef.current) return;
@@ -278,15 +212,9 @@ const ActionNodeEditor: FC<ActionNodeEditorProps> = ({ changeNodeType }) => {
             label="Node Type"
             options={nodeTypeOptions}
             onChange={selectNodeType}
-            value="action"
-          />
-          <DropDown
-            id="actionType"
-            label="Action Type"
-            options={actionTypeOptions}
-            onChange={selectActionType}
             value={resource.resourceType}
           />
+
           {(resource.resourceType === 'MedicationRequest' ||
             resource.resourceType === 'ServiceRequest') && (
             <>
@@ -337,7 +265,6 @@ const ActionNodeEditor: FC<ActionNodeEditorProps> = ({ changeNodeType }) => {
           )}
 
           {resource.resourceType === 'CarePlan' && (
-            // design for careplan ?
             <>
               <TextField
                 id="title-input"
@@ -360,6 +287,10 @@ const ActionNodeEditor: FC<ActionNodeEditorProps> = ({ changeNodeType }) => {
               )}
             </>
           )}
+
+          <h5 className={styles.dividerHeader}>
+            <span>Transitions</span>
+          </h5>
         </>
       )}
     </>

--- a/src/components/Sidebar/ActionNodeEditor.tsx
+++ b/src/components/Sidebar/ActionNodeEditor.tsx
@@ -18,13 +18,7 @@ import { usePathwaysContext } from 'components/PathwaysProvider';
 import { useCurrentPathwayContext } from 'components/CurrentPathwayProvider';
 import produce from 'immer';
 import { useCurrentNodeContext } from 'components/CurrentNodeProvider';
-
-const nodeTypeOptions = [
-  { label: 'Medication', value: 'MedicationRequest' },
-  { label: 'Procedure', value: 'ServiceRequest' },
-  { label: 'Regimen', value: 'CarePlan' },
-  { label: 'Observation', value: 'Observation' }
-];
+import { nodeTypeOptions } from 'utils/nodeUtils';
 
 const codeSystemOptions = [
   { label: 'ICD-9-CM', value: 'http://hl7.org/fhir/sid/icd-9-cm' },

--- a/src/components/Sidebar/BranchNodeEditor.tsx
+++ b/src/components/Sidebar/BranchNodeEditor.tsx
@@ -5,13 +5,7 @@ import DropDown from 'components/elements/DropDown';
 
 import useStyles from './styles';
 import { useCurrentNodeContext } from 'components/CurrentNodeProvider';
-
-const nodeTypeOptions = [
-  { label: 'Medication', value: 'MedicationRequest' },
-  { label: 'Procedure', value: 'ServiceRequest' },
-  { label: 'Regimen', value: 'CarePlan' },
-  { label: 'Observation', value: 'Observation' }
-];
+import { nodeTypeOptions } from 'utils/nodeUtils';
 
 interface BranchNodeEditorProps {
   changeNodeType: (event: string) => void;

--- a/src/components/Sidebar/BranchNodeEditor.tsx
+++ b/src/components/Sidebar/BranchNodeEditor.tsx
@@ -1,18 +1,21 @@
 import React, { FC, memo, useCallback, ChangeEvent } from 'react';
-import { faPlus } from '@fortawesome/free-solid-svg-icons';
 
-import { SidebarButton, BranchTransition } from '.';
+import { BranchTransition } from '.';
 import DropDown from 'components/elements/DropDown';
+<<<<<<< HEAD
 import { addTransition, createNode, addNode } from 'utils/builder';
 import { usePathwaysContext } from 'components/PathwaysProvider';
+=======
+>>>>>>> Support multiple transitions and update designs
 
 import useStyles from './styles';
-import { useCurrentPathwayContext } from 'components/CurrentPathwayProvider';
 import { useCurrentNodeContext } from 'components/CurrentNodeProvider';
 
 const nodeTypeOptions = [
-  { value: 'action', label: 'Action' },
-  { value: 'branch', label: 'Branch' }
+  { label: 'Medication', value: 'MedicationRequest' },
+  { label: 'Procedure', value: 'ServiceRequest' },
+  { label: 'Regimen', value: 'CarePlan' },
+  { label: 'Observation', value: 'Observation' }
 ];
 
 interface BranchNodeEditorProps {
@@ -20,9 +23,13 @@ interface BranchNodeEditorProps {
 }
 
 const BranchNodeEditor: FC<BranchNodeEditorProps> = ({ changeNodeType }) => {
+<<<<<<< HEAD
   const { updatePathway } = usePathwaysContext();
   const { pathwayRef } = useCurrentPathwayContext();
   const { currentNode, currentNodeRef } = useCurrentNodeContext();
+=======
+  const { currentNode } = useCurrentNodeContext();
+>>>>>>> Support multiple transitions and update designs
   const styles = useStyles();
 
   const selectNodeType = useCallback(
@@ -32,17 +39,6 @@ const BranchNodeEditor: FC<BranchNodeEditorProps> = ({ changeNodeType }) => {
     [changeNodeType]
   );
 
-  const handleAddTransition = useCallback((): void => {
-    if (!pathwayRef.current) return;
-
-    const newNode = createNode();
-
-    const newPathway = addNode(pathwayRef.current, newNode);
-    updatePathway(
-      addTransition(newPathway, currentNodeRef.current?.key || '', newNode.key as string)
-    );
-  }, [pathwayRef, updatePathway, currentNodeRef]);
-
   return (
     <>
       <DropDown
@@ -50,20 +46,16 @@ const BranchNodeEditor: FC<BranchNodeEditorProps> = ({ changeNodeType }) => {
         label="Node Type"
         options={nodeTypeOptions}
         onChange={selectNodeType}
-        value="branch"
+        value="Observation"
       />
+
+      <h5 className={styles.dividerHeader}>
+        <span>Transitions</span>
+      </h5>
+
       {currentNode?.transitions.map(transition => {
         return <BranchTransition key={transition.id} transition={transition} />;
       })}
-
-      <hr className={styles.divider} />
-
-      <SidebarButton
-        buttonName="Add Transition"
-        buttonIcon={faPlus}
-        buttonText="Add transition logic for a clinical decision within a workflow."
-        onClick={handleAddTransition}
-      />
     </>
   );
 };

--- a/src/components/Sidebar/BranchNodeEditor.tsx
+++ b/src/components/Sidebar/BranchNodeEditor.tsx
@@ -2,11 +2,6 @@ import React, { FC, memo, useCallback, ChangeEvent } from 'react';
 
 import { BranchTransition } from '.';
 import DropDown from 'components/elements/DropDown';
-<<<<<<< HEAD
-import { addTransition, createNode, addNode } from 'utils/builder';
-import { usePathwaysContext } from 'components/PathwaysProvider';
-=======
->>>>>>> Support multiple transitions and update designs
 
 import useStyles from './styles';
 import { useCurrentNodeContext } from 'components/CurrentNodeProvider';
@@ -23,13 +18,7 @@ interface BranchNodeEditorProps {
 }
 
 const BranchNodeEditor: FC<BranchNodeEditorProps> = ({ changeNodeType }) => {
-<<<<<<< HEAD
-  const { updatePathway } = usePathwaysContext();
-  const { pathwayRef } = useCurrentPathwayContext();
-  const { currentNode, currentNodeRef } = useCurrentNodeContext();
-=======
   const { currentNode } = useCurrentNodeContext();
->>>>>>> Support multiple transitions and update designs
   const styles = useStyles();
 
   const selectNodeType = useCallback(

--- a/src/components/Sidebar/BranchTransition.tsx
+++ b/src/components/Sidebar/BranchTransition.tsx
@@ -9,9 +9,9 @@ import React, {
   useRef
 } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faPlus, faSave, faTools, faTrashAlt } from '@fortawesome/free-solid-svg-icons';
+import { faSave, faTools, faTrashAlt, faThList } from '@fortawesome/free-solid-svg-icons';
 import DropDown from 'components/elements/DropDown';
-import { Button, Checkbox, FormControlLabel, TextField, Box } from '@material-ui/core';
+import { Button, Checkbox, FormControlLabel, TextField, Box, Card } from '@material-ui/core';
 import {
   removeTransitionCondition,
   setTransitionCondition,
@@ -136,15 +136,13 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition }) => {
   }, [buildCriteriaNodeId, handleBuildCriteriaCancel, transition]);
 
   return (
-    <>
-      <hr className={styles.divider} />
-
+    <Card raised className={styles.transitionContainer}>
       {transitionNode && <SidebarHeader node={transitionNode} isTransition={true} />}
 
       {!displayCriteria && !buildCriteriaSelected && (
         <SidebarButton
-          buttonName="Use Criteria"
-          buttonIcon={faPlus}
+          buttonName="Select Criteria"
+          buttonIcon={faThList}
           buttonText="Add previously built or imported criteria logic to branch node."
           onClick={handleUseCriteria}
         />
@@ -188,6 +186,7 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition }) => {
           buttonName="Build Criteria"
           buttonIcon={faTools}
           buttonText="Create new criteria logic to add to branch node."
+          extraMargin
           onClick={handleBuildCriteria}
         />
       )}
@@ -227,7 +226,7 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition }) => {
           </div>
         </OutlinedDiv>
       )}
-    </>
+    </Card>
   );
 };
 

--- a/src/components/Sidebar/NullNodeEditor.tsx
+++ b/src/components/Sidebar/NullNodeEditor.tsx
@@ -2,11 +2,13 @@ import React, { FC, memo, useCallback, ChangeEvent } from 'react';
 
 import DropDown from 'components/elements/DropDown';
 import { useCurrentNodeContext } from 'components/CurrentNodeProvider';
+import useStyles from './styles';
 
 const nodeTypeOptions = [
-  { label: '', value: '' },
-  { label: 'Action', value: 'action' },
-  { label: 'Branch', value: 'branch' }
+  { label: 'Medication', value: 'MedicationRequest' },
+  { label: 'Procedure', value: 'ServiceRequest' },
+  { label: 'Regimen', value: 'CarePlan' },
+  { label: 'Observation', value: 'Observation' }
 ];
 
 interface NullNodeEditorProps {
@@ -15,6 +17,7 @@ interface NullNodeEditorProps {
 
 const NullNodeEditor: FC<NullNodeEditorProps> = ({ changeNodeType }) => {
   const { currentNode } = useCurrentNodeContext();
+  const styles = useStyles();
   const selectNodeType = useCallback(
     (event: ChangeEvent<{ value: string }>): void => {
       changeNodeType(event?.target.value || '');
@@ -36,6 +39,9 @@ const NullNodeEditor: FC<NullNodeEditorProps> = ({ changeNodeType }) => {
           value=""
         />
       )}
+      <h5 className={styles.dividerHeader}>
+        <span>Transitions</span>
+      </h5>
     </>
   );
 };

--- a/src/components/Sidebar/NullNodeEditor.tsx
+++ b/src/components/Sidebar/NullNodeEditor.tsx
@@ -3,13 +3,7 @@ import React, { FC, memo, useCallback, ChangeEvent } from 'react';
 import DropDown from 'components/elements/DropDown';
 import { useCurrentNodeContext } from 'components/CurrentNodeProvider';
 import useStyles from './styles';
-
-const nodeTypeOptions = [
-  { label: 'Medication', value: 'MedicationRequest' },
-  { label: 'Procedure', value: 'ServiceRequest' },
-  { label: 'Regimen', value: 'CarePlan' },
-  { label: 'Observation', value: 'Observation' }
-];
+import { nodeTypeOptions } from 'utils/nodeUtils';
 
 interface NullNodeEditorProps {
   changeNodeType: (event: string) => void;

--- a/src/components/Sidebar/OutlinedDiv.tsx
+++ b/src/components/Sidebar/OutlinedDiv.tsx
@@ -35,6 +35,7 @@ const OutlinedDiv: FC<OutlinedDivProps> = ({ children, label, error }) => {
         }
       }}
       inputProps={{ children }}
+      fullWidth={true}
     />
   );
 };

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -89,8 +89,9 @@ const Sidebar: FC<SidebarProps> = ({ headerElement }) => {
   if (!currentNode) return <div>Error: No current node</div>;
 
   const nodeType = getNodeType(pathway, currentNode.key);
-  // If the node does not have transitions it can be added to
-  const displayAddButtons = currentNode.key !== undefined && currentNode.transitions.length === 0;
+  const displayAddButtons =
+    currentNode.key !== undefined &&
+    (currentNode.key !== 'Start' || currentNode.transitions.length === 0);
   return (
     <>
       {isExpanded && (

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,7 +1,12 @@
 import React, { FC, memo, useCallback, useState, useEffect, useRef, RefObject } from 'react';
 import { useHistory } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faChevronLeft, faChevronRight, faPlus } from '@fortawesome/free-solid-svg-icons';
+import {
+  faChevronLeft,
+  faChevronRight,
+  faPlus,
+  faLevelDownAlt
+} from '@fortawesome/free-solid-svg-icons';
 
 import {
   SidebarHeader,
@@ -15,6 +20,7 @@ import { usePathwaysContext } from 'components/PathwaysProvider';
 import useStyles from './styles';
 import { useCurrentPathwayContext } from 'components/CurrentPathwayProvider';
 import { useCurrentNodeContext } from 'components/CurrentNodeProvider';
+import { isBranchNode } from 'utils/nodeUtils';
 
 interface SidebarProps {
   headerElement: RefObject<HTMLDivElement>;
@@ -42,8 +48,8 @@ const Sidebar: FC<SidebarProps> = ({ headerElement }) => {
   );
 
   const redirectToNode = useCallback(
-    nodeKey => {
-      if (!pathwayRef.current) return;
+    (nodeKey: string | undefined) => {
+      if (!pathwayRef.current || !nodeKey) return;
 
       const url = `/builder/${encodeURIComponent(pathwayRef.current.id)}/node/${encodeURIComponent(
         nodeKey
@@ -55,23 +61,19 @@ const Sidebar: FC<SidebarProps> = ({ headerElement }) => {
     [history, pathwayRef]
   );
 
-  const addPathwayNode = useCallback(
-    (nodeType: string): void => {
-      if (!currentNodeRef.current?.key || !pathwayRef.current) return;
+  const addPathwayNode = useCallback((): void => {
+    if (!currentNodeRef.current?.key || !pathwayRef.current) return;
 
-      const newNode = createNode();
-      let newPathway = addNode(pathwayRef.current, newNode);
-      newPathway = addTransition(newPathway, currentNodeRef.current.key, newNode.key as string);
-      newPathway = setNodeType(newPathway, newNode.key as string, nodeType);
-      updatePathway(newPathway);
-      redirectToNode(newNode.key);
-    },
-    [pathwayRef, updatePathway, currentNodeRef, redirectToNode]
-  );
+    const newNode = createNode();
+    let newPathway = addNode(pathwayRef.current, newNode);
+    newPathway = addTransition(newPathway, currentNodeRef.current.key, newNode.key as string);
+    updatePathway(newPathway);
+    if (!isBranchNode(currentNodeRef.current)) redirectToNode(newNode.key);
+  }, [pathwayRef, updatePathway, currentNodeRef, redirectToNode]);
 
-  const addBranchNode = useCallback((): void => addPathwayNode('branch'), [addPathwayNode]);
-
-  const addActionNode = useCallback((): void => addPathwayNode('action'), [addPathwayNode]);
+  const connectToNode = useCallback((): void => {
+    console.log('Connect to existing node');
+  }, []);
 
   // Set the height of the sidebar container
   useEffect(() => {
@@ -89,7 +91,7 @@ const Sidebar: FC<SidebarProps> = ({ headerElement }) => {
   if (!currentNode) return <div>Error: No current node</div>;
 
   const nodeType = getNodeType(pathway, currentNode.key);
-  const displayAddButtons =
+  const displayTransitions =
     currentNode.key !== undefined &&
     (currentNode.key !== 'Start' || currentNode.transitions.length === 0);
   return (
@@ -98,7 +100,9 @@ const Sidebar: FC<SidebarProps> = ({ headerElement }) => {
         <div className={styles.root} ref={sidebarContainerElement}>
           <SidebarHeader node={currentNode} isTransition={false} />
 
-          <hr className={styles.divider} />
+          <h5 className={styles.dividerHeader}>
+            <span>Details</span>
+          </h5>
 
           {nodeType === 'null' && <NullNodeEditor changeNodeType={changeNodeType} />}
 
@@ -106,21 +110,20 @@ const Sidebar: FC<SidebarProps> = ({ headerElement }) => {
 
           {nodeType === 'branch' && <BranchNodeEditor changeNodeType={changeNodeType} />}
 
-          {displayAddButtons && (
+          {displayTransitions && (
             <>
-              {currentNode.key !== 'Start' && <hr className={styles.divider} />}
               <SidebarButton
-                buttonName="Add Action Node"
+                buttonName="Add New Node"
                 buttonIcon={faPlus}
-                buttonText="Any clinical or workflow step which is not a decision."
-                onClick={addActionNode}
+                buttonText="Add a new transition to a new node in the pathway."
+                onClick={addPathwayNode}
               />
 
               <SidebarButton
-                buttonName="Add Branch Node"
-                buttonIcon={faPlus}
-                buttonText="A logical branching point based on clinical or workflow criteria."
-                onClick={addBranchNode}
+                buttonName="Connect Node"
+                buttonIcon={faLevelDownAlt}
+                buttonText="Create a transition to an existing node in the pathway."
+                onClick={connectToNode}
               />
             </>
           )}

--- a/src/components/Sidebar/SidebarButton.tsx
+++ b/src/components/Sidebar/SidebarButton.tsx
@@ -9,14 +9,21 @@ interface SidebarButtonProps {
   buttonName: string;
   buttonIcon: IconDefinition;
   buttonText: string;
+  extraMargin?: boolean;
   onClick?: () => void;
 }
 
-const SidebarButton: FC<SidebarButtonProps> = ({ buttonName, buttonIcon, buttonText, onClick }) => {
+const SidebarButton: FC<SidebarButtonProps> = ({
+  buttonName,
+  buttonIcon,
+  buttonText,
+  extraMargin = false,
+  onClick
+}) => {
   const styles = useStyles();
 
   return (
-    <div className={styles.sidebarButtonGroup}>
+    <div className={extraMargin ? styles.sidebarButtonGroupExtraMargin : styles.sidebarButtonGroup}>
       <Button
         className={styles.sidebarButton}
         variant="contained"

--- a/src/components/Sidebar/SidebarHeader.tsx
+++ b/src/components/Sidebar/SidebarHeader.tsx
@@ -14,6 +14,7 @@ import { setNodeLabel } from 'utils/builder';
 import { usePathwaysContext } from 'components/PathwaysProvider';
 import useStyles from './styles';
 import { useCurrentPathwayContext } from 'components/CurrentPathwayProvider';
+import { useHistory } from 'react-router-dom';
 
 interface SidebarHeaderProps {
   node: PathwayNode;
@@ -27,14 +28,22 @@ const SidebarHeader: FC<SidebarHeaderProps> = ({ node, isTransition }) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const nodeLabel = node?.label || '';
   const styles = useStyles();
+  const history = useHistory();
 
   const goToParentNode = useCallback(() => {
     // TODO
   }, []);
 
-  const goToNode = useCallback(() => {
-    // TODO
-  }, []);
+  const redirectToNode = useCallback(() => {
+    if (!pathwayRef.current || !node.key) return;
+
+    const url = `/builder/${encodeURIComponent(pathwayRef.current.id)}/node/${encodeURIComponent(
+      node.key
+    )}`;
+    if (url !== history.location.pathname) {
+      history.push(url);
+    }
+  }, [history, pathwayRef, node.key]);
 
   const openNodeOptions = useCallback(() => {
     // TODO
@@ -105,7 +114,7 @@ const SidebarHeader: FC<SidebarHeaderProps> = ({ node, isTransition }) => {
       <div className={styles.sidebarHeaderGroup}>
         <IconButton
           className={styles.sidebarHeaderButton}
-          onClick={isTransition ? goToNode : openNodeOptions}
+          onClick={isTransition ? redirectToNode : openNodeOptions}
           aria-label={isTransition ? 'go to transition node' : 'open node options'}
         >
           <FontAwesomeIcon icon={isTransition ? faChevronRight : faEllipsisH} />

--- a/src/components/Sidebar/styles.tsx
+++ b/src/components/Sidebar/styles.tsx
@@ -7,9 +7,9 @@ export default makeStyles(
       flexDirection: 'column',
       padding: theme.variables.spacing.globalPadding,
       color: theme.palette.text.primary,
-      backgroundColor: theme.palette.grey['800'],
+      backgroundColor: theme.palette.common.gray,
       width: '33%',
-      minWidth: '500px',
+      minWidth: '550px',
       overflowY: 'scroll',
       float: 'left'
     },
@@ -64,6 +64,10 @@ export default makeStyles(
       display: 'flex',
       margin: '10px 0'
     },
+    sidebarButtonGroupExtraMargin: {
+      display: 'flex',
+      margin: '20px 0 10px 0'
+    },
     sidebarButton: {
       minWidth: 180,
       marginRight: '20px'
@@ -112,6 +116,25 @@ export default makeStyles(
     },
     saveButton: {
       marginLeft: '1em'
+    },
+    transitionContainer: {
+      backgroundColor: theme.palette.common.grayVeryDark,
+      padding: '0 15px 10px 15px',
+      margin: '15px 0'
+    },
+    dividerHeader: {
+      width: '100%',
+      textTransform: 'uppercase',
+      borderBottom: '1px solid ' + theme.palette.common.blueLighter,
+      color: theme.palette.common.blueLighter,
+      lineHeight: '0.1em',
+      margin: '10px 0 20px',
+      fontWeight: 800,
+      paddingLeft: '15px',
+      '& span': {
+        background: theme.palette.common.gray,
+        padding: '0 10px'
+      }
     }
   }),
   { name: 'Sidebar', index: 1 }

--- a/src/styles/_base.scss
+++ b/src/styles/_base.scss
@@ -11,7 +11,7 @@ html {
   box-sizing: inherit;
 }
 
-body {
+body, h1, h2, h3, h4, h5, h6 {
   margin: 0;
   font-family: 'Open Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',

--- a/src/styles/theme.tsx
+++ b/src/styles/theme.tsx
@@ -19,6 +19,21 @@ declare module '@material-ui/core/styles/createMuiTheme' {
   }
 }
 
+declare module '@material-ui/core/styles/createPalette' {
+  interface CommonColors {
+    blue: string;
+    blueLighter: string;
+    red: string;
+    gray: string;
+    grayMedium: string;
+    grayBlue: string;
+    grayLighter: string;
+    grayDark: string;
+    grayVeryDark: string;
+    green: string;
+  }
+}
+
 const variables = {
   spacing: {
     globalPadding: '2em'
@@ -28,13 +43,15 @@ const variables = {
 const colors = {
   white: '#fff',
   black: '#222',
-  blue: '#5d89a1',
   red: '#d95d77',
+  blue: '#5d89a1',
+  blueLighter: '#9ad2f0',
   gray: '#4a4a4a',
   grayMedium: '#bbbdc0',
   grayBlue: '#cbd5df',
   grayLighter: '#eaeef2',
   grayDark: '#444',
+  grayVeryDark: '#3a3a3a',
   green: '#2fa874'
 };
 
@@ -154,6 +171,11 @@ const materialUiOverridesBase = {
     root: {
       padding: '2em 4em'
     }
+  },
+  MuiCard: {
+    root: {
+      overflow: 'visible'
+    }
   }
 };
 
@@ -234,7 +256,7 @@ const paletteBase = {
     secondary: colors.gray
   },
   grey: {
-    800: '#4a4a4a'
+    800: colors.gray
   }
 };
 

--- a/src/utils/__tests__/builder.test.ts
+++ b/src/utils/__tests__/builder.test.ts
@@ -423,14 +423,16 @@ describe('builder interface update functions', () => {
   describe('setNodeType', () => {
     it('converts a branch node into a action node', () => {
       const key = 'N-test';
-      const newPathway = Builder.setNodeType(pathway, key, 'action');
+      const newPathway = Builder.setNodeType(pathway, key, 'ServiceRequest');
       expect(newPathway.nodes[key].cql).toEqual('');
+      expect(newPathway.nodes[key].action).toBeDefined();
     });
 
     it('converts a action node into a branch node', () => {
       const key = 'Surgery';
-      const newPathway = Builder.makeNodeBranch(pathway, key);
+      const newPathway = Builder.setNodeType(pathway, key, 'Observation');
       expect(newPathway.nodes[key].cql).not.toBeDefined();
+      expect(newPathway.nodes[key].action).not.toBeDefined();
     });
   });
 
@@ -484,6 +486,9 @@ describe('builder interface update functions', () => {
       expect(newPathway.nodes[key].cql).toEqual('');
       expect(newPathway.nodes[key].action).toEqual([]);
       expect(newPathway.nodes[key].nodeTypeIsUndefined).not.toBeDefined();
+      newPathway.nodes[key].transitions.forEach(transition => {
+        expect(transition.condition).not.toBeDefined();
+      });
     });
 
     it('does not modify its argument', () => {

--- a/src/utils/builder.ts
+++ b/src/utils/builder.ts
@@ -271,12 +271,65 @@ export function setNodeLabel(pathway: Pathway, key: string, label: string): Path
 }
 
 export function setNodeType(pathway: Pathway, nodeKey: string, nodeType: string): Pathway {
+  let action: Action;
+  let newPathway: Pathway;
   switch (nodeType) {
-    case 'action':
-      return makeNodeAction(pathway, nodeKey);
-    case 'branch':
+    case 'MedicationRequest':
+      newPathway = makeNodeAction(pathway, nodeKey);
+      action = {
+        type: 'create',
+        description: '',
+        id: shortid.generate(),
+        resource: {
+          resourceType: nodeType,
+          medicationCodeableConcept: {
+            coding: [
+              {
+                system: '',
+                code: '',
+                display: ''
+              }
+            ]
+          }
+        }
+      };
+      return setNodeAction(newPathway, nodeKey, [action]);
+    case 'ServiceRequest':
+      newPathway = makeNodeAction(pathway, nodeKey);
+      action = {
+        type: 'create',
+        description: '',
+        id: shortid.generate(),
+        resource: {
+          resourceType: nodeType,
+          code: {
+            coding: [
+              {
+                system: '',
+                code: '',
+                display: ''
+              }
+            ]
+          }
+        }
+      };
+      return setNodeAction(newPathway, nodeKey, [action]);
+    case 'CarePlan':
+      newPathway = makeNodeAction(pathway, nodeKey);
+      action = {
+        type: 'create',
+        description: '',
+        id: shortid.generate(),
+        resource: {
+          resourceType: nodeType,
+          title: ''
+        }
+      };
+      return setNodeAction(newPathway, nodeKey, [action]);
+    case 'Observation':
       return makeNodeBranch(pathway, nodeKey);
     default:
+      console.error('Unknown nodeType: ' + nodeType);
       return pathway;
   }
 }
@@ -543,6 +596,10 @@ export function makeNodeAction(pathway: Pathway, nodeKey: string): Pathway {
       node.action = [];
       node.nodeTypeIsUndefined = undefined;
     }
+
+    node.transitions.forEach(transition => {
+      delete transition.condition;
+    });
   });
 }
 

--- a/src/utils/nodeUtils.ts
+++ b/src/utils/nodeUtils.ts
@@ -18,3 +18,10 @@ export const resourceNameConversion: ConversionResource = {
   ServiceRequest: 'Procedure',
   CarePlan: 'Regimen'
 };
+
+export const nodeTypeOptions = [
+  { label: 'Medication', value: 'MedicationRequest' },
+  { label: 'Procedure', value: 'ServiceRequest' },
+  { label: 'Regimen', value: 'CarePlan' },
+  { label: 'Observation', value: 'Observation' }
+];

--- a/src/utils/nodeUtils.ts
+++ b/src/utils/nodeUtils.ts
@@ -6,8 +6,8 @@ export function isActionNode(node: PathwayNode): node is ActionNode {
 }
 
 export function isBranchNode(node: PathwayNode): boolean {
-  const { action, label } = node as ActionNode;
-  return action === undefined && label !== 'Start';
+  const { action, label, nodeTypeIsUndefined } = node as ActionNode;
+  return action === undefined && label !== 'Start' && !nodeTypeIsUndefined;
 }
 
 type ConversionResource = {


### PR DESCRIPTION
This PR includes the following changes:

- Supporting multiple transitions for action nodes
- Updating the Node Type drop down 
- Updating the transition UI and implementing go to node (right arrow)
- Update the add node buttons (connect node not implemented)
- Fix switch node type to remove transitions 

Supporting multiple transitions for action nodes:
![Screen Shot 2020-07-23 at 7 13 25 AM](https://user-images.githubusercontent.com/53485517/88280549-021f3280-ccb4-11ea-9ef4-4b2480a12e66.png)

Updating the Node Type drop down:
![Screen Shot 2020-07-23 at 7 12 54 AM](https://user-images.githubusercontent.com/53485517/88280506-efa4f900-ccb3-11ea-9e42-ea73ddd39f5b.png)

Updated UI components:
![Screen Shot 2020-07-23 at 7 11 53 AM](https://user-images.githubusercontent.com/53485517/88280430-cbe1b300-ccb3-11ea-809a-6b84db21b9fd.png)
