### PR TITLE
Update Highlights

### DIFF
--- a/src/components/Arrow/Arrow.module.scss
+++ b/src/components/Arrow/Arrow.module.scss
@@ -21,6 +21,6 @@
   @include arrow($blue);
 }
 
-.currentBranchArrow {
+.currentArrow {
   @include arrow($red);
 }

--- a/src/components/Arrow/Arrow.tsx
+++ b/src/components/Arrow/Arrow.tsx
@@ -1,7 +1,6 @@
 import React, { FC } from 'react';
 import { Edge, Coordinate } from 'graph-model';
 import { PathwayNode } from 'pathways-model';
-import { isBranchNode } from 'utils/nodeUtils';
 import useStyles from './styles';
 import clsx from 'clsx';
 import { Tooltip } from '@material-ui/core';
@@ -21,7 +20,7 @@ interface ArrowPathProps {
 
 const Arrow: FC<ArrowProps> = ({ edge, edgeName, widthOffset, currentNode }) => {
   const styles = useStyles();
-  const isCurrentBranchArrow = isBranchNode(currentNode) && edge.start === currentNode.key;
+  const isCurrentBranchArrow = edge.start === currentNode.key;
   const edgeNameNoWhitespace = edgeName.replace(' ', '');
   const arrowheadId = `arrowhead-${edgeNameNoWhitespace}`;
 

--- a/src/components/Arrow/Arrow.tsx
+++ b/src/components/Arrow/Arrow.tsx
@@ -20,13 +20,13 @@ interface ArrowPathProps {
 
 const Arrow: FC<ArrowProps> = ({ edge, edgeName, widthOffset, currentNode }) => {
   const styles = useStyles();
-  const isCurrentBranchArrow = edge.start === currentNode.key;
+  const isCurrentArrow = edge.start === currentNode.key;
   const edgeNameNoWhitespace = edgeName.replace(' ', '');
   const arrowheadId = `arrowhead-${edgeNameNoWhitespace}`;
 
   const { label } = edge;
   return (
-    <svg className={clsx(styles.arrow, isCurrentBranchArrow && styles.currentBranchArrow)}>
+    <svg className={clsx(styles.arrow, isCurrentArrow && styles.currentArrow)}>
       <ArrowPath points={edge.points} arrowheadId={arrowheadId} widthOffset={widthOffset} />
       {label ? (
         label.text.length > 12 ? (
@@ -44,7 +44,7 @@ const Arrow: FC<ArrowProps> = ({ edge, edgeName, widthOffset, currentNode }) => 
       <defs>
         <marker
           id={arrowheadId}
-          className={clsx(isCurrentBranchArrow ? styles.currentBranchArrowhead : styles.arrowhead)}
+          className={clsx(isCurrentArrow ? styles.currentArrowhead : styles.arrowhead)}
           markerWidth="10"
           markerHeight="7"
           refX="0"

--- a/src/components/Arrow/styles.tsx
+++ b/src/components/Arrow/styles.tsx
@@ -11,7 +11,7 @@ export default makeStyles(
         fontSize: '18px'
       }
     },
-    currentBranchArrow: {
+    currentArrow: {
       '& path': {
         stroke: theme.palette.secondary.main
       }
@@ -21,7 +21,7 @@ export default makeStyles(
         fill: theme.palette.primary.main
       }
     },
-    currentBranchArrowhead: {
+    currentArrowhead: {
       '& polygon': {
         fill: theme.palette.secondary.main
       }

--- a/src/components/Node/Node.tsx
+++ b/src/components/Node/Node.tsx
@@ -4,7 +4,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import styles from './Node.module.scss';
 import ExpandedNode from 'components/ExpandedNode';
-import { isActionNode, isBranchNode } from 'utils/nodeUtils';
+import { isActionNode } from 'utils/nodeUtils';
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import {
   faMicroscope,
@@ -58,16 +58,12 @@ const Node: FC<NodeProps & { ref: Ref<HTMLDivElement> }> = memo(
       };
 
       const isCurrentNode = pathwayNode.key === currentNode?.key;
-      const isTransitionOfCurrentBranch =
-        currentNode &&
-        isBranchNode(currentNode) &&
-        currentNode.transitions.some(e => e?.transition === nodeKey);
 
       const isActionable = isCurrentNode;
       const topLevelClasses = [styles.node];
       let expandedNodeClass = '';
       if (expanded) topLevelClasses.push('expanded');
-      if (isActionable || isTransitionOfCurrentBranch) {
+      if (isActionable) {
         topLevelClasses.push(styles.actionable);
         expandedNodeClass = styles.childActionable;
       } else {


### PR DESCRIPTION
Arrows to children are always red when the parent node is selected.
Children of observations are now blue instead of red.