### PR TITLE
Use the npm registry for json-schema@0.2.3

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6676,7 +6676,7 @@ json-schema-traverse@^0.4.1:
 
 json-schema@0.2.3:
   version "0.2.3"
-  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
+  resolved "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
   integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
 
 json-stable-stringify-without-jsonify@^1.0.1:


### PR DESCRIPTION
This manually updates our `yarn.lock` file to download the `json-schema@0.2.3` package from the npm registry instead of the yarn registry.

I noticed this locally when I removed my `node_modules` folder and reran `yarn install`. Yarn would output this error:

```
info There appears to be trouble with your network connection. Retrying...
error An unexpected error occurred: "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz: read ECONNRESET".
```

When I tried downloading the file via curl I get something similiar:

```
$ curl -v https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz
> GET /json-schema/-/json-schema-0.2.3.tgz HTTP/1.1
> Host: registry.yarnpkg.com
> User-Agent: curl/7.64.1
> Accept: */*
> 
* LibreSSL SSL_read: SSL_ERROR_SYSCALL, errno 54
* Closing connection 0
curl: (56) LibreSSL SSL_read: SSL_ERROR_SYSCALL, errno 54
```

I also checked with @blangley28 and he gets the same error when on VPN. I don't know if it is a MITRE-network specific thing or what, but something is blocking access to that file. I am able to download it from the npm registry, which is what this PR changes it to.

To test, run this on master, then on this branch:

```
rm -rf node_modules
yarn cache clean
yarn install
```