### PR TITLE
CPG Multiple Conditions

### DIFF
--- a/src/utils/__tests__/cpg.test.ts
+++ b/src/utils/__tests__/cpg.test.ts
@@ -1,5 +1,6 @@
 import samplepathway from './fixtures/sample_pathway.json';
-import { toCPG, createActivityDefinition, createPlanDefinition } from 'utils/cpg';
+import { toCPG, createActivityDefinition, createPlanDefinition, getExpressions } from 'utils/cpg';
+import { PlanDefinition } from 'fhir-objects';
 
 describe('convert pathway into cpg', () => {
   it('correctly converts sample pathway into cpg', () => {
@@ -11,6 +12,14 @@ describe('convert pathway into cpg', () => {
       expect(entry.resource).toBeDefined();
       expect(entry.request).toBeDefined();
     });
+    const strategydefinition = cpgPathway.entry[11].resource as PlanDefinition;
+    const otherRadiationAction = strategydefinition.action[2];
+    expect(otherRadiationAction.condition?.length).toBe(2);
+  });
+
+  it('gets all expressions from parent branch nodes', () => {
+    const expressions = getExpressions(samplepathway, samplepathway.nodes['OtherRadiation']);
+    expect(expressions.length).toBe(2);
   });
 
   describe('convert action into activity definition', () => {


### PR DESCRIPTION
The previous PR was missing applicability conditions for a chain of branch nodes. Updated to recursively check each parent to ensure all the conditions are included in the node. This works but there are still a few issues:
1. Right now duplicates are added (ie. the same condition may appear more than once)
2. This does not handle and/or correctly. Take the following 
![Screen Shot 2020-08-21 at 6 40 56 AM](https://user-images.githubusercontent.com/53485517/90882040-4700bc80-e379-11ea-9bf8-97525b41e74f.png)
For the `Chemotherapy TCH AC + TH` node the two conditions should be `N+` OR `N0 && T > 2cm`. However the code currently just pushes all of these applicability statements to the condition. According to the [PlanDefinition spec](https://www.hl7.org/fhir/plandefinition-definitions.html#PlanDefinition.action.condition), multiple applicability conditions means a logical AND. This is a problem since we want OR. I am unsure how ORs are supposed to be represented in PlanDefinitions but I can post in Zulip or created a Jira ticket for the CPG IG. It will be difficult (and annoying) if we have to say `N+ || N0` AND `N+ || T > 2cm`.
