### PR TITLE
Support multiple statements in ELM criteria import

### DIFF
--- a/src/components/CriteriaProvider.tsx
+++ b/src/components/CriteriaProvider.tsx
@@ -92,7 +92,6 @@ export const CriteriaProvider: FC<CriteriaProviderProps> = memo(({ children }) =
       if (event.target?.result) {
         const rawElm = event.target.result as string;
         const newCriteria = jsonToCriteria(rawElm);
-        console.log(newCriteria);
         if (newCriteria) setCriteria(currentCriteria => [...currentCriteria, ...newCriteria]);
       } else alert('Unable to read that file');
     };

--- a/src/components/Sidebar/BranchTransition.tsx
+++ b/src/components/Sidebar/BranchTransition.tsx
@@ -74,23 +74,18 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition }) => {
     (event: ChangeEvent<{ value: string }>): void => {
       if (!currentNodeRef.current?.key || !transitionRef.current.id || !pathwayRef.current) return;
 
-      const criteriaSource = event?.target.value || '';
-      let elm = undefined;
-      criteria.forEach(c => {
-        if (c.id === criteriaSource) {
-          elm = c.elm;
-        }
-      });
-      if (!elm) return;
+      const criteriaId = event?.target.value || '';
+      const selectedCriteria = criteria.find(c => c.id === criteriaId);
+      if (!selectedCriteria) return;
       const newPathway = setTransitionCondition(
         pathwayRef.current,
         currentNodeRef.current.key,
         transitionRef.current.id,
         transitionRef.current.condition?.description || '',
-        elm,
-        criteriaSource
+        selectedCriteria
       );
 
+      setCriteriaName(criteriaId);
       updatePathway(newPathway);
     },
     [currentNodeRef, updatePathway, pathwayRef, transitionRef, criteria]
@@ -204,7 +199,7 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition }) => {
               label="Criteria"
               options={criteriaOptions}
               onChange={selectCriteriaSource}
-              value={transition.condition?.criteriaSource || undefined}
+              value={criteriaName || undefined}
             />
 
             <TextField

--- a/src/components/Sidebar/BranchTransition.tsx
+++ b/src/components/Sidebar/BranchTransition.tsx
@@ -85,7 +85,6 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition }) => {
         selectedCriteria
       );
 
-      setCriteriaName(criteriaId);
       updatePathway(newPathway);
     },
     [currentNodeRef, updatePathway, pathwayRef, transitionRef, criteria]
@@ -151,16 +150,14 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition }) => {
     cql += `define "${criteriaName}":
       ${currentCriteriaCql.cql}`;
     const elm = await convertBasicCQL(cql);
-    const criteriaId = addElmCriteria(elm, criteriaName);
+    const criteria = addElmCriteria(elm);
 
     const newPathway = setTransitionCondition(
       pathwayRef.current,
       currentNodeRef.current.key,
       transitionRef.current.id,
       criteriaName,
-      elm,
-      criteriaId,
-      currentCriteriaCql.cql
+      criteria[0]
     );
 
     updatePathway(newPathway);
@@ -199,7 +196,7 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition }) => {
               label="Criteria"
               options={criteriaOptions}
               onChange={selectCriteriaSource}
-              value={criteriaName || undefined}
+              value={transition.condition?.criteriaSource || undefined}
             />
 
             <TextField

--- a/src/types/criteria-model.d.ts
+++ b/src/types/criteria-model.d.ts
@@ -1,0 +1,12 @@
+declare module 'criteria-model' {
+  import { ElmLibrary } from 'elm-model';
+
+  export interface Criteria {
+    id: string;
+    label: string;
+    version: string;
+    modified: number;
+    elm: ElmLibrary;
+    statement: string;
+  }
+}

--- a/src/utils/__tests__/builder.test.ts
+++ b/src/utils/__tests__/builder.test.ts
@@ -1,6 +1,8 @@
 import samplepathway from './fixtures/sample_pathway.json';
 import * as Builder from 'utils/builder';
 import { Pathway, Precondition, Transition, Action, ActionNode } from 'pathways-model';
+import { ElmLibrary } from 'elm-model';
+import { Criteria } from 'criteria-model';
 
 describe('builder interface add functions', () => {
   // Create a deep copy of the pathway
@@ -324,6 +326,14 @@ describe('builder interface update functions', () => {
       valueSets: { def: [] }
     }
   };
+  const criteria: Criteria = {
+    id: '1',
+    label: 'label',
+    version: '1.0',
+    modified: Date.now(),
+    elm: elm as ElmLibrary,
+    statement: 'Tumor Size'
+  };
 
   it('set pathway name', () => {
     const newPathway = Builder.setPathwayName(pathway, 'test name');
@@ -369,7 +379,7 @@ describe('builder interface update functions', () => {
       startNodeKey,
       transitionId,
       'test description',
-      elm
+      criteria
     );
     const expectedTransition = {
       id: '1',
@@ -401,7 +411,12 @@ describe('builder interface update functions', () => {
   it('set transition condition elm', () => {
     const startNodeKey = 'T-test';
     const transitionId = '1';
-    const newPathway = Builder.setTransitionConditionElm(pathway, startNodeKey, transitionId, elm);
+    const newPathway = Builder.setTransitionConditionElm(
+      pathway,
+      startNodeKey,
+      transitionId,
+      criteria
+    );
     expect(newPathway.nodes[startNodeKey].transitions[0].condition.cql).toBe('Tumor Size');
   });
 

--- a/src/utils/__tests__/builder.test.ts
+++ b/src/utils/__tests__/builder.test.ts
@@ -386,9 +386,9 @@ describe('builder interface update functions', () => {
       transition: 'Radiation',
       condition: {
         description: 'test description',
-        cql: '',
+        cql: 'Tumor Size',
         elm: elm,
-        criteriaSource: 'Tumor Size'
+        criteriaSource: '1'
       }
     };
     expect(newPathway.nodes[startNodeKey].transitions[0]).toEqual(expectedTransition);

--- a/src/utils/builder.ts
+++ b/src/utils/builder.ts
@@ -393,7 +393,8 @@ export function setTransitionCondition(
       foundTransition.condition = {
         description: description,
         cql: criteria.statement,
-        elm: criteria.elm
+        elm: criteria.elm,
+        criteriaSource: criteria.id
       };
   });
 }

--- a/src/utils/builder.ts
+++ b/src/utils/builder.ts
@@ -12,6 +12,7 @@ import shortid from 'shortid';
 import { MedicationRequest, ServiceRequest } from 'fhir-objects';
 import produce from 'immer';
 import { toCPG } from './cpg';
+import { Criteria } from 'criteria-model';
 
 export function createNewPathway(name: string, description?: string, pathwayId?: string): Pathway {
   return {
@@ -381,23 +382,19 @@ export function setTransitionCondition(
   startNodeKey: string,
   transitionId: string,
   description: string,
-  elm: ElmLibrary,
-  criteriaSource?: string,
-  cql?: string
+  criteria: Criteria
 ): Pathway {
   return produce(pathway, (draftPathway: Pathway) => {
     const foundTransition = draftPathway.nodes[startNodeKey]?.transitions?.find(
       (transition: Transition) => transition.id === transitionId
     );
 
-    if (foundTransition) {
+    if (foundTransition)
       foundTransition.condition = {
-        description,
-        elm,
-        criteriaSource: criteriaSource ?? getElmStatement(elm).name,
-        cql: cql ?? ''
+        description: description,
+        cql: criteria.statement,
+        elm: criteria.elm
       };
-    }
   });
 }
 
@@ -507,7 +504,7 @@ export function setTransitionConditionElm(
   pathway: Pathway,
   startNodeKey: string,
   transitionId: string,
-  elm: ElmLibrary
+  criteria: Criteria
 ): Pathway {
   return produce(pathway, (draftPathway: Pathway) => {
     const foundTransition = draftPathway.nodes[startNodeKey]?.transitions?.find(
@@ -515,8 +512,8 @@ export function setTransitionConditionElm(
     );
 
     if (foundTransition?.condition) {
-      foundTransition.condition.elm = elm;
-      foundTransition.condition.cql = getElmStatement(elm).name;
+      foundTransition.condition.elm = criteria.elm;
+      foundTransition.condition.cql = criteria.statement;
     }
   });
 }


### PR DESCRIPTION
Importing an ELM file for criteria all statements (minus the default ones which were already excluded) are imported. The underlying Elm library is the same for both criteria but the statement is different. This statement is used to populate the `transition.condition.cql` while the elm library is used for the `transition.condition.elm`. [Test JSON file](https://jira.mitre.org/secure/attachment/42397/Node-Size.json) which has two statements (N0 and N+) for testing - when importing the file you will see both statements appear in the criteria list