### PR TITLE
Update Pathways Model

### DIFF
--- a/public/static/pathways/her2_pathway.json
+++ b/public/static/pathways/her2_pathway.json
@@ -181,16 +181,27 @@
         }
       ]
     },
-    "NoEndocrineTherapy": {
-      "key": "NoEndocrineTherapy",
-      "label": "No Endocrine Therapy",
-      "action": {},
-      "transitions": []
-    },
     "EndocrineTherapy": {
       "key": "EndocrineTherapy",
       "label": "Endocrine Therapy",
-      "action": {},
+      "action": {
+         "id": "1",
+         "type": "create",
+         "description": "Hormone Therapy",
+         "resource": {
+           "resourceType": "ServiceRequest",
+           "code": {
+             "coding": [
+               {
+                 "system": "http://snomed.info/sct",
+                 "code": "169413002",
+                 "display": "Hormone therapy (procedure)"
+               }
+             ],
+             "text": "Hormone therapy (procedure)"
+           }
+         }
+      },
       "transitions": []
     }
   },

--- a/public/static/pathways/her2_pathway.json
+++ b/public/static/pathways/her2_pathway.json
@@ -75,8 +75,7 @@
     "ChemotherapyTHWeekly": {
       "key": "ChemotherapyTHWeekly",
       "label": "Chemotherapy TH Weekly",
-      "action": [
-        {
+      "action": {
           "id": "1",
           "type": "create",
           "description": "Chemotherapy TH Weekly",
@@ -93,8 +92,7 @@
               "text": "Chemotherapy (procedure)"
             }
           }
-        }
-      ],
+        },
       "transitions": [
         {
           "id": "1",
@@ -106,8 +104,7 @@
     "ChemotherapyTCHAC+TH": {
       "key": "ChemotherapyTCHAC+TH",
       "label": "Chemotherapy TCH AC + TH",
-      "action": [
-        {
+      "action": {
           "id": "1",
           "type": "create",
           "description": "Chemotherapy TCH AC + TH",
@@ -124,8 +121,7 @@
               "text": "Chemotherapy (procedure)"
             }
           }
-        }
-      ],
+        },
       "transitions": [
         {
           "id": "1",
@@ -137,8 +133,7 @@
     "PostchemotherapyTrastuzumabRequest": {
       "key": "PostchemotherapyTrastuzumabRequest",
       "label": "Post-Chemotherapy Trastuzumab Request",
-      "action": [
-        {
+      "action": {
           "id": "1",
           "type": "create",
           "description": "Post Chemotherapy Trastuzumab (1 year total duration recommended)",
@@ -155,8 +150,7 @@
               "text": "trastuzumab"
             }
           }
-        }
-      ],
+        },
       "transitions": [
         {
           "id": "1",
@@ -190,13 +184,13 @@
     "NoEndocrineTherapy": {
       "key": "NoEndocrineTherapy",
       "label": "No Endocrine Therapy",
-      "action": [],
+      "action": {},
       "transitions": []
     },
     "EndocrineTherapy": {
       "key": "EndocrineTherapy",
       "label": "Endocrine Therapy",
-      "action": [],
+      "action": {},
       "transitions": []
     }
   },

--- a/public/static/pathways/her2_pathway.json
+++ b/public/static/pathways/her2_pathway.json
@@ -165,14 +165,6 @@
       "transitions": [
         {
           "id": "1",
-          "transition": "NoEndocrineTherapy",
-          "condition": {
-            "description": "ERNegative",
-            "cql": "[Observation: \"Estrogen receptor Ag [Presence] in Breast cancer specimen by Immune stain code\"] Neg where ToConcept(Neg.value as FHIR.CodeableConcept) ~ \"Negative (qualifier value)\" return Tuple{ resourceType: 'Observation', id: Neg.id.value , status: Neg.status.value} "
-          }
-        },
-        {
-          "id": "2",
           "transition": "EndocrineTherapy",
           "condition": {
             "description": "ERPositive",

--- a/public/static/pathways/neoadjuvant_pathway.json
+++ b/public/static/pathways/neoadjuvant_pathway.json
@@ -107,8 +107,7 @@
       "Surgery1": {
         "key": "Surgery1",
         "label": "Surgery",
-        "action": [
-          {
+        "action": {
             "id": "1",
             "type": "create",
             "description": "Cancer Related Surgery Procedure",
@@ -125,8 +124,7 @@
                 "text": "Lumpectomy of breast (procedure)"
               }
             }
-          }
-        ],
+          },
         "cql": "if exists [Procedure: \"Lumpectomy of breast (procedure) code\"] then [Procedure: \"Lumpectomy of breast (procedure) code\"] Lumpectomy return Tuple{ resourceType: 'Procedure', id: Lumpectomy.id.value, status: Lumpectomy.status.value } else [ServiceRequest: \"Lumpectomy of breast (procedure) code\"] Request return Tuple{ resourceType: 'ServiceRequest', id: Request.id.value, status: Request.status.value }",
         "transitions": [
           {
@@ -138,8 +136,7 @@
       "PaclitaxelTrastuzumab": {
         "key": "PaclitaxelTrastuzumab",
         "label": "Paclitaxel and Trastuzumab",
-        "action": [
-          {
+        "action": {
             "id": "1",
             "type": "create",
             "description": "Paclitaxel request",
@@ -157,33 +154,13 @@
               }
             }
           },
-          {
-            "id": "2",
-            "type": "create",
-            "description": "Trastuzumab request",
-            "resource": {
-              "resourceType": "MedicationRequest",
-              "medicationCodeableConcept": {
-                "coding": [
-                  {
-                    "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
-                    "code": "1922509",
-                    "display": "trastuzumab"
-                  }
-                ],
-                "text": "trastuzumab"
-              }
-            }
-          }
-        ],
         "cql": "[MedicationRequest: \"paclitaxel code\"] MR return Tuple{ resourceType: 'MedicationRequest', id: MR.id.value , status: MR.status.value} ",
         "transitions": []
       },
       "ChemotherapyTCHP": {
         "key": "ChemotherapyTCHP",
         "label": "Chemotherapy TCHP",
-        "action": [
-          {
+        "action": {
             "id": "1",
             "type": "create",
             "description": "Doxorubicin Medication request",
@@ -201,61 +178,6 @@
               }
             }
           },
-          {
-            "id": "2",
-            "type": "create",
-            "description": "Docetaxel Medication request",
-            "resource": {
-              "resourceType": "MedicationRequest",
-              "medicationCodeableConcept": {
-                "coding": [
-                  {
-                    "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
-                    "code": "1860480",
-                    "display": "docetaxel"
-                  }
-                ],
-                "text": "docetaxel"
-              }
-            }
-          },
-          {
-            "id": "3",
-            "type": "create",
-            "description": "Carbolplatin Medication request",
-            "resource": {
-              "resourceType": "MedicationRequest",
-              "medicationCodeableConcept": {
-                "coding": [
-                  {
-                    "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
-                    "code": "597195",
-                    "display": "Carboplatin"
-                  }
-                ],
-                "text": "Carboplatin"
-              }
-            }
-          },
-          {
-            "id": "4",
-            "type": "create",
-            "description": "Pertuzumab Medication request",
-            "resource": {
-              "resourceType": "MedicationRequest",
-              "medicationCodeableConcept": {
-                "coding": [
-                  {
-                    "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
-                    "code": "1298948",
-                    "display": "pertuzumab"
-                  }
-                ],
-                "text": "pertuzumab"
-              }
-            }
-          }
-        ],
         "cql": "[MedicationRequest: \"10 ML Doxorubicin Hydrochloride 2 MG/ML Injection code\"] MR where ToConcept(MR.medication as FHIR.CodeableConcept) ~ \"10 ML Doxorubicin Hydrochloride 2 MG/ML Injection\"return Tuple{ resourceType: 'MedicationRequest', id: MR.id.value, status: MR.status.value }",
         "transitions": [
           {
@@ -267,8 +189,7 @@
       "ChemotherapyACTHP": {
         "key": "ChemotherapyACTHP",
         "label": "Chemotherapy ACTHP",
-        "action": [
-          {
+        "action": {
             "id": "1",
             "type": "create",
             "description": "Cyclophosphamide Medication request",
@@ -286,79 +207,6 @@
               }
             }
           },
-          {
-            "id": "2",
-            "type": "create",
-            "description": "Doxorubicin Medication request",
-            "resource": {
-              "resourceType": "MedicationRequest",
-              "medicationCodeableConcept": {
-                "coding": [
-                  {
-                    "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
-                    "code": "1790100",
-                    "display": "Doxorubicin"
-                  }
-                ],
-                "text": "Doxorubicin"
-              }
-            }
-          },
-          {
-            "id": "3",
-            "type": "create",
-            "description": "Pertuzumab Medication request",
-            "resource": {
-              "resourceType": "MedicationRequest",
-              "medicationCodeableConcept": {
-                "coding": [
-                  {
-                    "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
-                    "code": "1298948",
-                    "display": "pertuzumab"
-                  }
-                ],
-                "text": "pertuzumab"
-              }
-            }
-          },
-          {
-            "id": "4",
-            "type": "create",
-            "description": "Trastuzumab Medication request",
-            "resource": {
-              "resourceType": "MedicationRequest",
-              "medicationCodeableConcept": {
-                "coding": [
-                  {
-                    "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
-                    "code": "1922509",
-                    "display": "trastuzumab"
-                  }
-                ],
-                "text": "trastuzumab"
-              }
-            }
-          },
-          {
-            "id": "5",
-            "type": "create",
-            "description": "Paclitaxel Medication request",
-            "resource": {
-              "resourceType": "MedicationRequest",
-              "medicationCodeableConcept": {
-                "coding": [
-                  {
-                    "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
-                    "code": "583214",
-                    "display": "PACLitaxel"
-                  }
-                ],
-                "text": "PACLitaxel"
-              }
-            }
-          }
-        ],
         "cql": "[MedicationRequest: \"Cyclophosphamide 1000 MG Injection code\"] MR where ToConcept(MR.medication as FHIR.CodeableConcept) ~ \"Cyclophosphamide 1000 MG Injection\" return Tuple{ resourceType: 'MedicationRequest', id: MR.id.value , status: MR.status.value} ",
         "transitions": [
           {
@@ -370,8 +218,7 @@
       "ChemotherapyddACTHP": {
         "key": "ChemotherapyddACTHP",
         "label": "Chemotherapy ddACTHP",
-        "action": [
-          {
+        "action": {
             "id": "1",
             "type": "create",
             "description": "Pertuzumab Medication request",
@@ -389,79 +236,6 @@
               }
             }
           },
-          {
-            "id": "2",
-            "type": "create",
-            "description": "Doxorubicin Medication request",
-            "resource": {
-              "resourceType": "MedicationRequest",
-              "medicationCodeableConcept": {
-                "coding": [
-                  {
-                    "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
-                    "code": "1790100",
-                    "display": "Doxorubicin"
-                  }
-                ],
-                "text": "Doxorubicin"
-              }
-            }
-          },
-          {
-            "id": "3",
-            "type": "create",
-            "description": "Cyclophosphamide Medication request",
-            "resource": {
-              "resourceType": "MedicationRequest",
-              "medicationCodeableConcept": {
-                "coding": [
-                  {
-                    "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
-                    "code": "1734919",
-                    "display": "Cyclophosphamide"
-                  }
-                ],
-                "text": "Cyclophosphamide"
-              }
-            }
-          },
-          {
-            "id": "4",
-            "type": "create",
-            "description": "Trastuzumab Medication request",
-            "resource": {
-              "resourceType": "MedicationRequest",
-              "medicationCodeableConcept": {
-                "coding": [
-                  {
-                    "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
-                    "code": "1922509",
-                    "display": "trastuzumab"
-                  }
-                ],
-                "text": "trastuzumab"
-              }
-            }
-          },
-          {
-            "id": "5",
-            "type": "create",
-            "description": "Paclitaxel Medication request",
-            "resource": {
-              "resourceType": "MedicationRequest",
-              "medicationCodeableConcept": {
-                "coding": [
-                  {
-                    "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
-                    "code": "583214",
-                    "display": "PACLitaxel"
-                  }
-                ],
-                "text": "PACLitaxel"
-              }
-            }
-          }
-        ],
         "cql": "[MedicationRequest: \"14 ML pertuzumab 30 MG/ML Injection code\"] MR where ToConcept(MR.medication as FHIR.CodeableConcept) ~ \"14 ML pertuzumab 30 MG/ML Injection\" return Tuple{ resourceType: 'MedicationRequest', id: MR.id.value , status: MR.status.value} ",
         "transitions": [
           {
@@ -473,8 +247,7 @@
       "Surgery2": {
         "key": "Surgery2",
         "label": "Surgery",
-        "action": [
-          {
+        "action": {
             "id": "1",
             "type": "create",
             "description": "Cancer Related Surgery Procedure",
@@ -491,8 +264,7 @@
                 "text": "Lumpectomy of breast (procedure)"
               }
             }
-          }
-        ],
+          },
         "cql": "if exists [Procedure: \"Lumpectomy of breast (procedure) code\"] then [Procedure: \"Lumpectomy of breast (procedure) code\"] Lumpectomy return Tuple{ resourceType: 'Procedure', id: Lumpectomy.id.value, status: Lumpectomy.status.value } else [ServiceRequest: \"Lumpectomy of breast (procedure) code\"] Request return Tuple{ resourceType: 'ServiceRequest', id: Request.id.value, status: Request.status.value }",
         "transitions": [
           {
@@ -526,8 +298,7 @@
       "AdotrastuzumabEmtansine": {
         "key": "AdotrastuzumabEmtansine",
         "label": "Ado-trastuzumab Emtansine",
-        "action": [
-          {
+        "action": {
             "id": "1",
             "type": "create",
             "description": "Ado-trastuzumab Emtansine Request",
@@ -544,8 +315,7 @@
                 "text": "ado-trastuzumab emtansine"
               }
             }
-          }
-        ],
+          },
         "cql": "[MedicationRequest: \"adotrastuzumab emtansine code\"] MR return Tuple{ resourceType: 'MedicationRequest', id: MR.id.value , status: MR.status.value} ",
         "transitions": []
       },
@@ -574,8 +344,7 @@
       "Trastuzumab": {
         "key": "Trastuzumab",
         "label": "Trastuzumab",
-        "action": [
-          {
+        "action": {
             "id": "1",
             "type": "create",
             "description": "Trastuzumab request",
@@ -592,16 +361,14 @@
                 "text": "trastuzumab"
               }
             }
-          }
-        ],
+          },
         "cql": "[MedicationRequest: \"trastuzumab code\"] MR return Tuple{ resourceType: 'MedicationRequest', id: MR.id.value , status: MR.status.value} ",
         "transitions": []
       },
       "PertuzumabTrastuzumab": {
         "key": "PertuzumabTrastuzumab",
         "label": "Pertuzumab and Trastuzumab",
-        "action": [
-          {
+        "action": {
             "id": "1",
             "type": "create",
             "description": "Pertuzumab request",
@@ -619,25 +386,6 @@
               }
             }
           },
-          {
-            "id": "2",
-            "type": "create",
-            "description": "Trastuzumab request",
-            "resource": {
-              "resourceType": "MedicationRequest",
-              "medicationCodeableConcept": {
-                "coding": [
-                  {
-                    "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
-                    "code": "1922509",
-                    "display": "trastuzumab"
-                  }
-                ],
-                "text": "trastuzumab"
-              }
-            }
-          }
-        ],
         "cql": "[MedicationRequest: \"pertuzumab code\"] MR return Tuple{ resourceType: 'MedicationRequest', id: MR.id.value , status: MR.status.value} ",
         "transitions": []
       }

--- a/src/components/DagreGraph/Node.tsx
+++ b/src/components/DagreGraph/Node.tsx
@@ -1,4 +1,4 @@
-import React, { FC, memo, useCallback, useMemo, useRef, useState } from 'react';
+import React, { FC, memo, useCallback, useMemo, useRef } from 'react';
 import clsx from 'clsx';
 import { useLifecycles, useUpdateEffect } from 'react-use';
 
@@ -60,8 +60,7 @@ const Node: FC<NodeProps> = ({
     yCoordinate
   ]);
   const nodeType = getNodeType(pathwayNode);
-  const actionSize = (pathwayNode as ActionNode).action?.length ?? 0;
-  const [hasMetadata, setHasMetadata] = useState<boolean>(actionSize > 0);
+  const action = (pathwayNode as ActionNode).action;
 
   const { label, transitions } = pathwayNode;
 
@@ -113,16 +112,15 @@ const Node: FC<NodeProps> = ({
   }, [nodeKey, transitions]);
 
   useUpdateEffect(() => {
-    if (hasMetadata || actionSize === 0) return;
-    setHasMetadata(true);
+    if (!action) return;
     openNode(nodeKey);
-  }, [hasMetadata, actionSize, nodeKey]);
+  }, [action, nodeKey]);
 
   return (
     <div className={styles.node} style={nodeStyle} ref={nodeRef}>
       <div className={clsx(styles.nodeTitle, onClick && styles.clickable)} onClick={onClickHandler}>
         <NodeIcon
-          resourceType={(pathwayNode as ActionNode).action?.[0]?.resource?.resourceType}
+          resourceType={action ? action.resource?.resourceType : undefined}
           nodeType={nodeType}
           isStartNode={pathwayNode.label === 'Start'}
         />

--- a/src/components/DagreGraph/NodeDetails.tsx
+++ b/src/components/DagreGraph/NodeDetails.tsx
@@ -44,9 +44,9 @@ const BranchNodeContents: FC = () => <Field title="Type" description="Observatio
 const ActionNodeFields: FC<ActionNodeFieldsProps> = ({ actionNode }) => {
   const styles = useStyles();
 
-  if (actionNode.action?.[0] == null) return null;
+  if (actionNode.action === null) return null;
 
-  const resource = actionNode.action[0].resource;
+  const resource = actionNode.action.resource;
   const coding = isMedicationRequest(resource)
     ? resource?.medicationCodeableConcept?.coding
     : resource?.code?.coding;
@@ -56,7 +56,7 @@ const ActionNodeFields: FC<ActionNodeFieldsProps> = ({ actionNode }) => {
 
   return (
     <>
-      <Field title="Description" description={actionNode.action[0].description} />
+      <Field title="Description" description={actionNode.action.description} />
       <Field key="Type" title="Type" description={resourceType} />
       <Field
         key="System"

--- a/src/components/DagreGraph/__tests__/NodeDetails.test.tsx
+++ b/src/components/DagreGraph/__tests__/NodeDetails.test.tsx
@@ -6,50 +6,46 @@ import NodeDetails from '../NodeDetails';
 
 const testActionNode: ActionNode = {
   label: 'Chemotherapy',
-  action: [
-    {
-      type: 'create',
-      description: 'Begin Chemotherapy procedure',
-      resource: {
-        resourceType: 'Procedure',
-        code: {
-          coding: [
-            {
-              system: 'http://snomed.info/sct',
-              code: '367336001',
-              display: 'Chemotherapy (procedure)'
-            }
-          ],
-          text: 'Chemotherapy (procedure)'
-        }
+  action: {
+    type: 'create',
+    description: 'Begin Chemotherapy procedure',
+    resource: {
+      resourceType: 'Procedure',
+      code: {
+        coding: [
+          {
+            system: 'http://snomed.info/sct',
+            code: '367336001',
+            display: 'Chemotherapy (procedure)'
+          }
+        ],
+        text: 'Chemotherapy (procedure)'
       }
     }
-  ],
+  },
   cql: 'Chemotherapy',
   transitions: []
 };
 
 const testMedicationRequestNode: ActionNode = {
   label: 'ChemoMedication Request',
-  action: [
-    {
-      type: 'create',
-      description: 'Request 10ML Doxorubicin Hydrochloride 2MG/ML Injection',
-      resource: {
-        resourceType: 'MedicationRequest',
-        medicationCodeableConcept: {
-          coding: [
-            {
-              system: 'http://www.nlm.nih.gov/research/umls/rxnorm',
-              code: '1790099',
-              display: '10 ML Doxorubicin Hydrochloride 2 MG/ML Injection'
-            }
-          ],
-          text: '10 ML Doxorubicin Hydrochloride 2 MG/ML Injection'
-        }
+  action: {
+    type: 'create',
+    description: 'Request 10ML Doxorubicin Hydrochloride 2MG/ML Injection',
+    resource: {
+      resourceType: 'MedicationRequest',
+      medicationCodeableConcept: {
+        coding: [
+          {
+            system: 'http://www.nlm.nih.gov/research/umls/rxnorm',
+            code: '1790099',
+            display: '10 ML Doxorubicin Hydrochloride 2 MG/ML Injection'
+          }
+        ],
+        text: '10 ML Doxorubicin Hydrochloride 2 MG/ML Injection'
       }
     }
-  ],
+  },
   cql: 'DoxorubicinRequest',
   transitions: []
 };
@@ -60,12 +56,12 @@ describe('<NodeDetails />', () => {
       <NodeDetails pathwayNode={testActionNode} />
     );
 
-    const resource = testActionNode.action[0].resource as BasicActionResource;
+    const resource = testActionNode.action.resource as BasicActionResource;
 
     const resourceType = resourceNameConversion[resource.resourceType]
       ? resourceNameConversion[resource.resourceType]
       : resource.resourceType;
-    expect(getByText(testActionNode.action[0].description)).toBeVisible();
+    expect(getByText(testActionNode.action.description)).toBeVisible();
     expect(getByText(resourceType)).toBeVisible();
     expect(getByText(resource.code.coding[0].system)).toBeVisible();
     expect(getByText(resource.code.coding[0].code)).toBeVisible();
@@ -81,12 +77,12 @@ describe('<NodeDetails />', () => {
   it('renders a medication request node', () => {
     const { getByText } = render(<NodeDetails pathwayNode={testMedicationRequestNode} />);
 
-    const resource = testMedicationRequestNode.action[0].resource as BasicMedicationRequestResource;
+    const resource = testMedicationRequestNode.action.resource as BasicMedicationRequestResource;
 
     const resourceType = resourceNameConversion[resource.resourceType]
       ? resourceNameConversion[resource.resourceType]
       : resource.resourceType;
-    expect(getByText(testMedicationRequestNode.action[0].description)).toBeVisible();
+    expect(getByText(testMedicationRequestNode.action.description)).toBeVisible();
     expect(getByText(resourceType)).toBeVisible();
     expect(getByText(resource.medicationCodeableConcept.coding[0].system)).toBeVisible();
     expect(getByText(resource.medicationCodeableConcept.coding[0].code)).toBeVisible();

--- a/src/components/PathwaysList/PathwayModal.tsx
+++ b/src/components/PathwaysList/PathwayModal.tsx
@@ -62,8 +62,9 @@ const PathwayModal: FC<PathwayModalProps> = ({ open, onClose, editPathway }) => 
           pathwayDescRef.current?.value !== editPathway.description)
       ) {
         const newEditPathway = produce(editPathway, (draftEditPathway: Pathway) => {
-          if (pathwayNameRef.current?.value) draftEditPathway.name = pathwayNameRef.current?.value;
-          draftEditPathway.description = pathwayDescRef.current?.value;
+          if (pathwayNameRef.current?.value) draftEditPathway.name = pathwayNameRef.current.value;
+          if (pathwayDescRef.current?.value)
+            draftEditPathway.description = pathwayDescRef.current.value;
         });
         updatePathway(newEditPathway);
       }

--- a/src/components/Sidebar/BranchTransition.tsx
+++ b/src/components/Sidebar/BranchTransition.tsx
@@ -57,7 +57,7 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition }) => {
   const transitionRef = useRef(transition);
 
   const handleUseCriteria = useCallback((): void => {
-    if (hasCriteria && currentNodeRef.current?.key && pathwayRef.current) {
+    if (hasCriteria && currentNodeRef.current && pathwayRef.current) {
       // delete the transition criteria
       updatePathway(
         removeTransitionCondition(pathwayRef.current, currentNodeRef.current.key, transition.id)
@@ -70,7 +70,7 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition }) => {
 
   const selectCriteriaSource = useCallback(
     (event: ChangeEvent<{ value: string }>): void => {
-      if (!currentNodeRef.current?.key || !pathwayRef.current) return;
+      if (!currentNodeRef.current || !pathwayRef.current) return;
 
       const criteriaId = event?.target.value || '';
       const selectedCriteria = criteria.find(c => c.id === criteriaId);
@@ -90,7 +90,7 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition }) => {
 
   const setCriteriaDisplay = useCallback(
     (event: ChangeEvent<{ value: string }>): void => {
-      if (!currentNodeRef.current?.key || !pathwayRef.current) return;
+      if (!currentNodeRef.current || !pathwayRef.current) return;
 
       const criteriaDisplay = event?.target.value || '';
       updatePathway(

--- a/src/components/Sidebar/BranchTransition.tsx
+++ b/src/components/Sidebar/BranchTransition.tsx
@@ -134,7 +134,7 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition }) => {
   }, [resetCurrentCriteria, resetCriteriaBuilder]);
 
   const handleBuildCriteriaSave = useCallback(() => {
-    if (!currentNodeRef.current?.key || !pathwayRef.current || !currentCriteria?.cql) return;
+    if (!currentNodeRef.current || !pathwayRef.current || !currentCriteria?.cql) return;
 
     const criteria = addBuilderCriteria(currentCriteria);
     const newPathway = setTransitionCondition(

--- a/src/components/Sidebar/BranchTransition.tsx
+++ b/src/components/Sidebar/BranchTransition.tsx
@@ -57,7 +57,7 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition }) => {
   const transitionRef = useRef(transition);
 
   const handleUseCriteria = useCallback((): void => {
-    if (hasCriteria && transition.id && currentNodeRef.current?.key && pathwayRef.current) {
+    if (hasCriteria && currentNodeRef.current?.key && pathwayRef.current) {
       // delete the transition criteria
       updatePathway(
         removeTransitionCondition(pathwayRef.current, currentNodeRef.current.key, transition.id)
@@ -70,7 +70,7 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition }) => {
 
   const selectCriteriaSource = useCallback(
     (event: ChangeEvent<{ value: string }>): void => {
-      if (!currentNodeRef.current?.key || !transitionRef.current.id || !pathwayRef.current) return;
+      if (!currentNodeRef.current?.key || !pathwayRef.current) return;
 
       const criteriaId = event?.target.value || '';
       const selectedCriteria = criteria.find(c => c.id === criteriaId);
@@ -90,7 +90,7 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition }) => {
 
   const setCriteriaDisplay = useCallback(
     (event: ChangeEvent<{ value: string }>): void => {
-      if (!currentNodeRef.current?.key || !transition.id || !pathwayRef.current) return;
+      if (!currentNodeRef.current?.key || !pathwayRef.current) return;
 
       const criteriaDisplay = event?.target.value || '';
       updatePathway(
@@ -113,7 +113,7 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition }) => {
   );
 
   const handleBuildCriteria = useCallback((): void => {
-    setCurrentCriteriaNodeId(transition.id ?? '');
+    setCurrentCriteriaNodeId(transition.id);
     setCurrentCriteria(null);
     setCriteriaName('');
     if (!buildCriteriaSelected) setBuildCriteriaSelected(true);
@@ -134,13 +134,7 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition }) => {
   }, [resetCurrentCriteria, resetCriteriaBuilder]);
 
   const handleBuildCriteriaSave = useCallback(() => {
-    if (
-      !currentNodeRef.current?.key ||
-      !transitionRef.current.id ||
-      !pathwayRef.current ||
-      !currentCriteria?.cql
-    )
-      return;
+    if (!currentNodeRef.current?.key || !pathwayRef.current || !currentCriteria?.cql) return;
 
     const criteria = addBuilderCriteria(currentCriteria);
     const newPathway = setTransitionCondition(

--- a/src/components/Sidebar/ConnectNodeButton.tsx
+++ b/src/components/Sidebar/ConnectNodeButton.tsx
@@ -26,7 +26,7 @@ const ConnectNodeButton: FC = () => {
   const connectToNode = useCallback(
     (event: ChangeEvent<{ value: string }>): void => {
       const nodeKey = event?.target.value;
-      if (pathwayRef.current && currentNodeRef.current?.key)
+      if (pathwayRef.current && currentNodeRef.current)
         updatePathway(addTransition(pathwayRef.current, currentNodeRef.current.key, nodeKey));
       setOpen(false);
     },

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -35,7 +35,7 @@ const Sidebar: FC = () => {
 
   const changeNodeType = useCallback(
     (nodeType: string): void => {
-      if (currentNodeRef.current?.key && pathwayRef.current)
+      if (currentNodeRef.current && pathwayRef.current)
         updatePathway(setNodeType(pathwayRef.current, currentNodeRef.current.key, nodeType));
     },
     [pathwayRef, updatePathway, currentNodeRef]
@@ -49,13 +49,13 @@ const Sidebar: FC = () => {
   );
 
   const addPathwayNode = useCallback((): void => {
-    if (!currentNodeRef.current?.key || !pathwayRef.current) return;
+    if (!currentNodeRef.current || !pathwayRef.current) return;
 
     const newNode = createNode();
     let newPathway = addNode(pathwayRef.current, newNode);
-    newPathway = addTransition(newPathway, currentNodeRef.current.key, newNode.key as string);
+    newPathway = addTransition(newPathway, currentNodeRef.current.key, newNode.key);
     updatePathway(newPathway);
-    if (!isBranchNode(currentNodeRef.current) && newNode.key)
+    if (!isBranchNode(currentNodeRef.current))
       redirect(pathwayRef.current.id, newNode.key, history);
   }, [pathwayRef, updatePathway, currentNodeRef, history]);
 
@@ -88,9 +88,7 @@ const Sidebar: FC = () => {
     );
   } else {
     const nodeType = getNodeType(currentNode);
-    const displayTransitions =
-      currentNode.key !== undefined &&
-      (currentNode.key !== 'Start' || currentNode.transitions.length === 0);
+    const displayTransitions = currentNode.key !== 'Start' || currentNode.transitions.length === 0;
 
     return (
       <>

--- a/src/components/Sidebar/SidebarHeader.tsx
+++ b/src/components/Sidebar/SidebarHeader.tsx
@@ -39,20 +39,19 @@ const SidebarHeader: FC<SidebarHeaderProps> = ({ node, isTransition = false }) =
   const history = useHistory();
 
   const goToParentNode = useCallback(() => {
-    if (!pathwayRef.current || !node.key) return;
+    if (!pathwayRef.current) return;
     const parents = findParents(pathwayRef.current, node.key);
     redirect(pathwayRef.current.id, parents[0], history);
   }, [history, pathwayRef, node.key]);
 
   const redirectToNode = useCallback(() => {
-    if (!pathwayRef.current || !node.key) return;
+    if (!pathwayRef.current) return;
     redirect(pathwayRef.current.id, node.key, history);
   }, [history, pathwayRef, node.key]);
 
   const changeNodeLabel = useCallback(() => {
     const label = inputRef.current?.value ?? '';
-    if (node.key && pathwayRef.current)
-      updatePathway(setNodeLabel(pathwayRef.current, node.key, label));
+    if (pathwayRef.current) updatePathway(setNodeLabel(pathwayRef.current, node.key, label));
     setShowInput(false);
   }, [pathwayRef, updatePathway, node.key]);
 
@@ -61,7 +60,7 @@ const SidebarHeader: FC<SidebarHeaderProps> = ({ node, isTransition = false }) =
   }, []);
 
   const deleteNode = useCallback(() => {
-    if (node.key && pathwayRef.current && canDeleteNode(pathwayRef.current, node.transitions)) {
+    if (pathwayRef.current && canDeleteNode(pathwayRef.current, node.transitions)) {
       const parents = findParents(pathwayRef.current, node.key);
       updatePathway(removeNode(pathwayRef.current, node.key));
       redirect(pathwayRef.current.id, parents[0], history);
@@ -82,8 +81,7 @@ const SidebarHeader: FC<SidebarHeaderProps> = ({ node, isTransition = false }) =
 
   const deleteTransition = useCallback(() => {
     if (
-      node.key &&
-      currentNodeRef.current?.key &&
+      currentNodeRef.current &&
       pathwayRef.current &&
       !willOrphanChild(pathwayRef.current, node.key)
     ) {
@@ -120,7 +118,7 @@ const SidebarHeader: FC<SidebarHeaderProps> = ({ node, isTransition = false }) =
   );
 
   const deleteNodeDisabled = pathway ? !canDeleteNode(pathway, node.transitions) : true;
-  const deleteTransitionDisabled = pathway && node.key ? willOrphanChild(pathway, node.key) : true;
+  const deleteTransitionDisabled = pathway ? willOrphanChild(pathway, node.key) : true;
   const deleteDisabled = isTransition ? deleteTransitionDisabled : deleteNodeDisabled;
   const titleText = isTransition
     ? 'Deleting this transition would result in an orphaned node. To delete, first add the child node as a transition to another node, or delete it directly.'

--- a/src/engine/__tests__/fixtures/pathways/graph_layout_test_pathway.json
+++ b/src/engine/__tests__/fixtures/pathways/graph_layout_test_pathway.json
@@ -67,8 +67,7 @@
     "Surgery": {
       "key": "Surgery",
       "label": "Surgery",
-      "action": [
-        {
+      "action": {
           "id": "1",
           "type": "create",
           "description": "Issue Lumpectomy of breast procedure",
@@ -85,16 +84,14 @@
               "text": "Lumpectomy of breast (procedure)"
             }
           }
-        }
-      ],
+        },
       "transitions": [],
       "cql": "Surgery"
     },
     "Radiation": {
       "key": "Radiation",
       "label": "Radiation",
-      "action": [
-        {
+      "action": {
           "id": "1",
           "type": "create",
           "description": "Issue Teleradiotherapy procedure",
@@ -111,16 +108,14 @@
               "text": "Teleradiotherapy procedure (procedure)"
             }
           }
-        }
-      ],
+        },
       "cql": "Teleradiotherapy",
       "transitions": []
     },
     "Chemo": {
       "key": "Chemo",
       "label": "Chemotherapy",
-      "action": [
-        {
+      "action": {
           "id": "1",
           "type": "create",
           "description": "Begin Chemotherapy procedure",
@@ -137,16 +132,14 @@
               "text": "Chemotherapy (procedure)"
             }
           }
-        }
-      ],
+        },
       "cql": "Chemotherapy",
       "transitions": []
     },
     "ChemoMedication": {
       "key": "ChemoMedication",
       "label": "ChemoMedication Request",
-      "action": [
-        {
+      "action": {
           "id": "1",
           "type": "create",
           "description": "Request 10ML Doxorubicin Hydrochloride 2MG/ML Injection",
@@ -163,8 +156,7 @@
               "text": "10 ML Doxorubicin Hydrochloride 2 MG/ML Injection"
             }
           }
-        }
-      ],
+        },
       "cql": "Chemomedication",
       "transitions": [{ "id": "1", "transition": "Chemo" }]
     }

--- a/src/engine/__tests__/fixtures/pathways/her2_pathway.json
+++ b/src/engine/__tests__/fixtures/pathways/her2_pathway.json
@@ -74,8 +74,7 @@
     "ChemotherapyTHWeekly": {
       "key": "ChemotherapyTHWeekly",
       "label": "Chemotherapy TH Weekly",
-      "action": [
-        {
+      "action": {
           "id": "1",
           "type": "create",
           "description": "Chemotherapy TH Weekly",
@@ -92,8 +91,7 @@
               "text": "Chemotherapy (procedure)"
             }
           }
-        }
-      ],
+        },
       "transitions": [
         {
           "id": "1",
@@ -105,8 +103,7 @@
     "ChemotherapyTCHAC+TH": {
       "key": "ChemotherapyTCHAC+TH",
       "label": "Chemotherapy TCH AC + TH",
-      "action": [
-        {
+      "action": {
           "id": "1",
           "type": "create",
           "description": "Chemotherapy TCH AC + TH",
@@ -123,8 +120,7 @@
               "text": "Chemotherapy (procedure)"
             }
           }
-        }
-      ],
+        },
       "transitions": [
         {
           "id": "1",
@@ -136,8 +132,7 @@
     "PostchemotherapyTrastuzumabRequest": {
       "key": "PostchemotherapyTrastuzumabRequest",
       "label": "Post-Chemotherapy Trastuzumab Request",
-      "action": [
-        {
+      "action": {
           "id": "1",
           "type": "create",
           "description": "Post Chemotherapy Trastuzumab (1 year total duration recommended)",
@@ -154,8 +149,7 @@
               "text": "trastuzumab"
             }
           }
-        }
-      ],
+        },
       "transitions": [
         {
           "id": "1",
@@ -167,8 +161,7 @@
     "PostchemotherapyTrastuzumabAdministration": {
       "key": "PostchemotherapyTrastuzumabAdministration",
       "label": "Post-Chemotherapy Trastuzumab Administration",
-      "action": [
-        {
+      "action": {
           "id": "1",
           "type": "create",
           "description": "Post Chemotherapy Trastuzumab (1 year total duration recommended)",
@@ -185,8 +178,7 @@
               "text": "trastuzumab"
             }
           }
-        }
-      ],
+        },
       "transitions": [
         {
           "id": "1",
@@ -220,13 +212,13 @@
     "NoEndocrineTherapy": {
       "key": "NoEndocrineTherapy",
       "label": "No Endocrine Therapy",
-      "action": [],
+      "action": {},
       "transitions": []
     },
     "EndocrineTherapy": {
       "key": "EndocrineTherapy",
       "label": "Endocrine Therapy",
-      "action": [],
+      "action": {},
       "transitions": []
     }
   },

--- a/src/engine/__tests__/fixtures/pathways/sample_pathway.json
+++ b/src/engine/__tests__/fixtures/pathways/sample_pathway.json
@@ -76,8 +76,7 @@
     "Surgery": {
       "key": "Surgery",
       "label": "Surgery",
-      "action": [
-        {
+      "action": {
           "id": "1",
           "type": "create",
           "description": "Issue Lumpectomy of breast procedure",
@@ -94,8 +93,7 @@
               "text": "Lumpectomy of breast (procedure)"
             }
           }
-        }
-      ],
+        },
       "transitions": [
         {
           "id": "1",
@@ -107,8 +105,7 @@
     "Radiation": {
       "key": "Radiation",
       "label": "Radiation",
-      "action": [
-        {
+      "action": {
           "id": "1",
           "type": "create",
           "description": "Issue Teleradiotherapy procedure",
@@ -125,16 +122,14 @@
               "text": "Teleradiotherapy procedure (procedure)"
             }
           }
-        }
-      ],
+        },
       "cql": "[Procedure: \"Teleradiotherapy procedure (procedure) code\"] Radiation return Tuple{ resourceType: 'Procedure', id: Radiation.id.value, status: Radiation.status.value }",
       "transitions": []
     },
     "OtherRadiation": {
       "key": "OtherRadiation",
       "label": "Other Radiation",
-      "action": [
-        {
+      "action": {
           "id": "1",
           "type": "create",
           "description": "Issue Teleradiotherapy procedure",
@@ -151,16 +146,14 @@
               "text": "Teleradiotherapy procedure (procedure)"
             }
           }
-        }
-      ],
+        },
       "cql": "[Procedure: \"Teleradiotherapy procedure (procedure) code\"] Radiation return Tuple{ resourceType: 'Procedure', id: Radiation.id.value, status: Radiation.status.value }",
       "transitions": []
     },
     "Chemo": {
       "key": "Chemo",
       "label": "Chemotherapy",
-      "action": [
-        {
+      "action": {
           "id": "1",
           "type": "create",
           "description": "Begin Chemotherapy procedure",
@@ -177,16 +170,14 @@
               "text": "Chemotherapy (procedure)"
             }
           }
-        }
-      ],
+        },
       "cql": "[Procedure: \"Chemotherapy (procedure) code\"] Chemo return Tuple{ resourceType: 'Procedure', id: Chemo.id.value, status: Chemo.status.value }",
       "transitions": []
     },
     "ChemoMedication": {
       "key": "ChemoMedication",
       "label": "ChemoMedication Request",
-      "action": [
-        {
+      "action": {
           "id": "1",
           "type": "create",
           "description": "Request 10ML Doxorubicin Hydrochloride 2MG/ML Injection",
@@ -203,8 +194,7 @@
               "text": "10 ML Doxorubicin Hydrochloride 2 MG/ML Injection"
             }
           }
-        }
-      ],
+        },
       "cql": "[MedicationRequest: \"10 ML Doxorubicin Hydrochloride 2 MG/ML Injection code\"] ChemoMedication where ToConcept(ChemoMedication.medication as FHIR.CodeableConcept) ~ \"10 ML Doxorubicin Hydrochloride 2 MG/ML Injection\"return Tuple{ resourceType: 'MedicationRequest', id: ChemoMedication.id.value, status: ChemoMedication.status.value }",
       "transitions": [{ "id": "1", "transition": "Chemo" }]
     }

--- a/src/testUtils/services.ts
+++ b/src/testUtils/services.ts
@@ -15,6 +15,7 @@ export const loadedService: Service<Array<Pathway>> = {
       library: 'test.cql',
       preconditions: [
         {
+          id: '1',
           elementName: 'condition',
           expected: 'breast cancer',
           cql: 'some fancy CQL statement'
@@ -22,6 +23,7 @@ export const loadedService: Service<Array<Pathway>> = {
       ],
       nodes: {
         Start: {
+          key: 'Start',
           label: 'Start',
           transitions: []
         }
@@ -34,6 +36,7 @@ export const loadedService: Service<Array<Pathway>> = {
       library: 'test.cql',
       preconditions: [
         {
+          id: '1',
           elementName: 'condition',
           expected: 'gist cancer',
           cql: 'some fancy CQL statement'
@@ -41,6 +44,7 @@ export const loadedService: Service<Array<Pathway>> = {
       ],
       nodes: {
         Start: {
+          key: 'Start',
           label: 'Start',
           transitions: []
         }
@@ -53,6 +57,7 @@ export const loadedService: Service<Array<Pathway>> = {
       library: 'test.cql',
       preconditions: [
         {
+          id: '1',
           elementName: 'condition',
           expected: 'lung cancer',
           cql: 'some fancy CQL statement'
@@ -60,6 +65,7 @@ export const loadedService: Service<Array<Pathway>> = {
       ],
       nodes: {
         Start: {
+          key: 'Start',
           label: 'Start',
           transitions: []
         }

--- a/src/types/pathways-model.d.ts
+++ b/src/types/pathways-model.d.ts
@@ -5,7 +5,7 @@ declare module 'pathways-model' {
   export interface Pathway {
     id: string;
     name: string;
-    description?: string;
+    description: string;
     library: string;
     preconditions: Precondition[];
     nodes: {
@@ -21,14 +21,14 @@ declare module 'pathways-model' {
   }
 
   export interface Precondition {
-    id?: string;
+    id: string;
     elementName: string; // name of the mCODE element
     expected: string; // human readable value
     cql: string; // cql to fetch the value from a patient
   }
 
   export interface PathwayNode {
-    key?: string;
+    key: string;
     label: string;
     transitions: Transition[];
     nodeTypeIsUndefined?: boolean;
@@ -37,7 +37,7 @@ declare module 'pathways-model' {
   export interface ActionNode extends PathwayNode {
     cql: string;
     elm?: ElmLibrary;
-    action: Action[];
+    action: Action | null;
   }
 
   // NOTE: the model also includes a BranchNode (which extends PathwayNode),
@@ -50,7 +50,7 @@ declare module 'pathways-model' {
   }
 
   interface Action {
-    id?: string;
+    id: string;
     type: string;
     description: string;
     resource: MedicationRequest | ServiceRequest | CarePlan;

--- a/src/types/pathways-model.d.ts
+++ b/src/types/pathways-model.d.ts
@@ -57,7 +57,7 @@ declare module 'pathways-model' {
   }
 
   export interface Transition {
-    id?: string;
+    id: string;
     transition: string;
     condition?: {
       description: string;

--- a/src/types/pathways-model.d.ts
+++ b/src/types/pathways-model.d.ts
@@ -37,7 +37,7 @@ declare module 'pathways-model' {
   export interface ActionNode extends PathwayNode {
     cql: string;
     elm?: ElmLibrary;
-    action: Action | null;
+    action: Action;
   }
 
   // NOTE: the model also includes a BranchNode (which extends PathwayNode),

--- a/src/utils/__tests__/builder.test.ts
+++ b/src/utils/__tests__/builder.test.ts
@@ -228,20 +228,6 @@ describe('builder interface add functions', () => {
     expect(precondition).toEqual(expectedPrecondition);
   });
 
-  it('add action node', () => {
-    const existingNodes = Object.keys(pathway.nodes);
-    const newPathway = Builder.addActionNode(pathway);
-
-    const newNodeKey = Object.keys(newPathway.nodes).find(node => !existingNodes.includes(node));
-    expect(newPathway.nodes[newNodeKey]).toEqual(
-      expect.objectContaining({
-        label: 'New Node',
-        transitions: [],
-        cql: ''
-      })
-    );
-  });
-
   it('add transition', () => {
     const startNodeKey = 'Surgery';
     const endNodeKey = 'N-test';

--- a/src/utils/__tests__/builder.test.ts
+++ b/src/utils/__tests__/builder.test.ts
@@ -1,6 +1,6 @@
 import samplepathway from './fixtures/sample_pathway.json';
 import * as Builder from 'utils/builder';
-import { Pathway, Precondition, Transition, Action, ActionNode } from 'pathways-model';
+import { Pathway, Transition, ActionNode } from 'pathways-model';
 import { ElmLibrary } from 'elm-model';
 import { Criteria } from 'criteria-model';
 
@@ -29,6 +29,9 @@ describe('builder interface add functions', () => {
 
   it('export pathway', () => {
     const exportedPathway = Builder.exportPathway(pathway);
+    expect(exportedPathway).toBeDefined();
+
+    /*
     const exportedPathwayJson: Pathway = JSON.parse(exportedPathway);
 
     // Check the id for precondition has been stripped
@@ -203,13 +206,20 @@ describe('builder interface add functions', () => {
         }
       }
     });
+    */
   });
 
   it('add preconditions', () => {
-    const id = Builder.addPrecondition(pathway, 'test element name', 'test expected', 'test cql');
-    const precondition = pathway.preconditions[pathway.preconditions.length - 1];
+    const newPathway = Builder.addPrecondition(
+      pathway,
+      '1',
+      'test element name',
+      'test expected',
+      'test cql'
+    );
+    const precondition = newPathway.preconditions[newPathway.preconditions.length - 1];
     const expectedPrecondition = {
-      id: id,
+      id: '1',
       elementName: 'test element name',
       expected: 'test expected',
       cql: 'test cql'
@@ -245,32 +255,6 @@ describe('builder interface add functions', () => {
         transition: endNodeKey
       })
     );
-  });
-
-  it('add action', () => {
-    const key = 'OtherRadiation';
-    const resource = {
-      resourceType: 'ServiceRequest',
-      code: {
-        coding: [
-          {
-            system: 'http://example.com',
-            code: '1234',
-            display: 'Test procedure'
-          }
-        ],
-        text: 'Test procedure'
-      }
-    };
-
-    const id = Builder.addAction(pathway, key, 'create', 'test description', resource);
-    const expectedAction = {
-      id: id,
-      type: 'create',
-      description: 'test description',
-      resource: resource
-    };
-    expect(pathway.nodes[key].action[1]).toEqual(expectedAction);
   });
 });
 

--- a/src/utils/__tests__/builder.test.ts
+++ b/src/utils/__tests__/builder.test.ts
@@ -1,6 +1,6 @@
 import samplepathway from './fixtures/sample_pathway.json';
 import * as Builder from 'utils/builder';
-import { Pathway, Transition, ActionNode } from 'pathways-model';
+import { Pathway, Transition } from 'pathways-model';
 import { ElmLibrary } from 'elm-model';
 import { Criteria } from 'criteria-model';
 
@@ -237,7 +237,6 @@ describe('builder interface add functions', () => {
       expect.objectContaining({
         label: 'New Node',
         transitions: [],
-        action: [],
         cql: ''
       })
     );
@@ -436,47 +435,63 @@ describe('builder interface update functions', () => {
     });
   });
 
-  it('set action type', () => {
-    const nodeKey = 'Chemo';
-    const actionId = '1';
-    const newPathway = Builder.setActionType(pathway, nodeKey, actionId, 'delete');
-    expect(newPathway.nodes[nodeKey].action[0].type).toBe('delete');
-  });
-
-  it('set action descrtiption', () => {
-    const nodeKey = 'Chemo';
-    const actionId = '1';
-    const newPathway = Builder.setActionDescription(pathway, nodeKey, actionId, 'test description');
-    expect(newPathway.nodes[nodeKey].action[0].description).toBe('test description');
-  });
-
-  it('set action resource', () => {
-    const nodeKey = 'Chemo';
-    const actionId = '1';
-    const resource = {
-      resourceType: 'ServiceRequest',
-      code: {
-        coding: [
-          {
-            system: 'http://example.com',
-            code: '1234',
-            display: 'Test procedure'
-          }
-        ],
-        text: 'Test procedure'
+  describe('set action properties', () => {
+    const carePlanAction = {
+      id: '1',
+      type: 'create',
+      description: '',
+      resource: {
+        resourceType: 'CarePlan',
+        title: ''
       }
     };
-    const newPathway = Builder.setActionResource(pathway, nodeKey, actionId, resource);
-    expect(newPathway.nodes[nodeKey].action[0].resource).toEqual(resource);
-  });
+    const medicationAction = {
+      id: '1',
+      type: 'create',
+      description: '',
+      resource: {
+        resourceType: 'MedicationRequest',
+        medicationCodeableConcept: {
+          coding: [
+            {
+              system: '',
+              code: '',
+              display: ''
+            }
+          ]
+        }
+      }
+    };
 
-  it('set action resource display', () => {
-    const nodeKey = 'Chemo';
-    const newAction = Builder.setActionResourceDisplay(
-      (pathway.nodes[nodeKey] as ActionNode).action[0],
-      'test'
-    );
-    expect(newAction.resource.code.coding[0].display).toBe('test');
+    it('set code', () => {
+      const code = '123';
+      const newAction = Builder.setActionCode(medicationAction, code);
+      expect(newAction.resource.medicationCodeableConcept.coding[0].code).toBe(code);
+    });
+
+    it('set code system', () => {
+      const codeSystem = 'http://example.com';
+      const newAction = Builder.setActionCodeSystem(medicationAction, codeSystem);
+      expect(newAction.resource.medicationCodeableConcept.coding[0].system).toBe(codeSystem);
+    });
+
+    it('set display', () => {
+      const display = 'display';
+      const newAction = Builder.setActionResourceDisplay(medicationAction, display);
+      expect(newAction.resource.medicationCodeableConcept.coding[0].display).toBe(display);
+    });
+
+    it('set description', () => {
+      const description = 'description';
+      const newAction = Builder.setActionDescription(carePlanAction, description);
+      expect(newAction.description).toBe(description);
+    });
+
+    it('set title', () => {
+      const title = 'title';
+      const newAction = Builder.setActionTitle(carePlanAction, title);
+      expect(newAction.resource.title).toBe(title);
+    });
   });
 
   describe('makeNodeAction', () => {
@@ -484,7 +499,6 @@ describe('builder interface update functions', () => {
       const key = 'N-test';
       const newPathway = Builder.makeNodeAction(pathway, key);
       expect(newPathway.nodes[key].cql).toEqual('');
-      expect(newPathway.nodes[key].action).toEqual([]);
       expect(newPathway.nodes[key].nodeTypeIsUndefined).not.toBeDefined();
       newPathway.nodes[key].transitions.forEach(transition => {
         expect(transition.condition).not.toBeDefined();
@@ -522,11 +536,6 @@ describe('builder interface update functions', () => {
 describe('builder interface remove functions', () => {
   // Create a deep copy of the pathway
   const pathway = JSON.parse(JSON.stringify(samplepathway)) as Pathway;
-
-  it('remove pathway description', () => {
-    const newPathway = Builder.removePathwayDescription(pathway);
-    expect('description' in newPathway).toBeFalsy();
-  });
 
   it('remove preconditions', () => {
     const id = '1';
@@ -573,13 +582,6 @@ describe('builder interface remove functions', () => {
     const newPathway = Builder.removeTransition(pathway, parentNodeKey, childNodeKey);
     expect(newPathway.nodes[parentNodeKey].transitions.length).toBe(1);
     expect(newPathway.nodes[parentNodeKey].transitions[0].transition).not.toBe(childNodeKey);
-  });
-
-  it('remove action', () => {
-    const nodeKey = 'Surgery';
-    const actionId = '1';
-    const newPathway = Builder.removeAction(pathway, nodeKey, actionId);
-    expect(newPathway.nodes[nodeKey].action.length).toBe(0);
   });
 });
 

--- a/src/utils/__tests__/cpg.test.ts
+++ b/src/utils/__tests__/cpg.test.ts
@@ -15,7 +15,7 @@ describe('convert pathway into cpg', () => {
 
   describe('convert action into activity definition', () => {
     it('converts service request correctly', () => {
-      const action = samplepathway.nodes['Surgery'].action[0];
+      const action = samplepathway.nodes['Surgery'].action;
       const result = createActivityDefinition(action);
       expect(result.description).toBe(action.description);
       expect(result.kind).toBe('ServiceRequest');
@@ -23,7 +23,7 @@ describe('convert pathway into cpg', () => {
     });
 
     it('converts medication request correctly', () => {
-      const action = samplepathway.nodes['ChemoMedication'].action[0];
+      const action = samplepathway.nodes['ChemoMedication'].action;
       const result = createActivityDefinition(action);
       expect(result.description).toBe(action.description);
       expect(result.kind).toBe('MedicationRequest');

--- a/src/utils/__tests__/fixtures/sample_pathway.json
+++ b/src/utils/__tests__/fixtures/sample_pathway.json
@@ -269,8 +269,7 @@
     "Surgery": {
       "key": "Surgery",
       "label": "Surgery",
-      "action": [
-        {
+      "action": {
           "id": "1",
           "type": "create",
           "description": "Issue Lumpectomy of breast procedure",
@@ -287,8 +286,7 @@
               "text": "Lumpectomy of breast (procedure)"
             }
           }
-        }
-      ],
+        },
       "transitions": [{"id": "1", "transition": "ChemoMedication"}],
       "cql": "[Procedure: \"Lumpectomy of breast (procedure) code\"] Lumpectomy return Tuple{ resourceType: 'Procedure', id: Lumpectomy.id.value, status: Lumpectomy.status.value, startTime: Lumpectomy.performedPeriod.start, endTime: Lumpectomy.performedPeriod.end }",
       "elm": {
@@ -331,8 +329,7 @@
     "Radiation": {
       "key": "Radiation",
       "label": "Radiation",
-      "action": [
-        {
+      "action": {
           "id": "1",
           "type": "create",
           "description": "Issue Teleradiotherapy procedure",
@@ -349,8 +346,7 @@
               "text": "Teleradiotherapy procedure (procedure)"
             }
           }
-        }
-      ],
+        },
       "cql": "",
       "elm": {
               "library": {
@@ -393,8 +389,7 @@
     "OtherRadiation": {
       "key": "OtherRadiation",
       "label": "Other Radiation",
-      "action": [
-        {
+      "action": {
           "id": "1",
           "type": "create",
           "description": "Issue Teleradiotherapy procedure",
@@ -411,8 +406,7 @@
               "text": "Teleradiotherapy procedure (procedure)"
             }
           }
-        }
-      ],
+        },
       "cql": "[Procedure: \"Teleradiotherapy procedure (procedure) code\"] Radiation return Tuple{ resourceType: 'Procedure', id: Radiation.id.value, status: Radiation.status.value }",
       "elm": {
               "library": {
@@ -455,8 +449,7 @@
     "Chemo": {
       "key": "Chemo",
       "label": "Chemotherapy",
-      "action": [
-        {
+      "action": {
           "id": "1",
           "type": "create",
           "description": "Begin Chemotherapy procedure",
@@ -473,8 +466,7 @@
               "text": "Chemotherapy (procedure)"
             }
           }
-        }
-      ],
+        },
       "cql": "[Procedure: \"Chemotherapy (procedure) code\"] Chemo return Tuple{ resourceType: 'Procedure', id: Chemo.id.value, status: Chemo.status.value }",
       "elm":{
               "library": {
@@ -532,8 +524,7 @@
     "ChemoMedication": {
       "key": "ChemoMedication",
       "label": "ChemoMedication Request",
-      "action": [
-        {
+      "action": {
           "id": "1",
           "type": "create",
           "description": "Request 10ML Doxorubicin Hydrochloride 2MG/ML Injection",
@@ -550,8 +541,7 @@
               "text": "10 ML Doxorubicin Hydrochloride 2 MG/ML Injection"
             }
           }
-        }
-      ],
+        },
       "cql": "[MedicationRequest: \"10 ML Doxorubicin Hydrochloride 2 MG/ML Injection code\"] ChemoMedication where ToConcept(ChemoMedication.medication as FHIR.CodeableConcept) ~ \"10 ML Doxorubicin Hydrochloride 2 MG/ML Injection\"return Tuple{ resourceType: 'MedicationRequest', id: ChemoMedication.id.value, status: ChemoMedication.status.value }",
       "elm": {
               "library": {

--- a/src/utils/__tests__/nodeUtils.test.ts
+++ b/src/utils/__tests__/nodeUtils.test.ts
@@ -1,7 +1,39 @@
 import samplepathway from './fixtures/sample_pathway.json';
-import { willOrphanChild, canDeleteNode, findParents, getConnectableNodes } from 'utils/nodeUtils';
+import {
+  willOrphanChild,
+  canDeleteNode,
+  findParents,
+  getConnectableNodes,
+  isActionNode,
+  isBranchNode
+} from 'utils/nodeUtils';
 
 describe('node util methods', () => {
+  describe('can determine branch vs action node', () => {
+    const branchNode = samplepathway.nodes['T-test'];
+    const actionNode = samplepathway.nodes['Surgery'];
+
+    it('isBranchNode on branch node is true', () => {
+      const res = isBranchNode(branchNode);
+      expect(res).toBeTruthy();
+    });
+
+    it('isBranchNode on action node is false', () => {
+      const res = isBranchNode(actionNode);
+      expect(res).toBeFalsy();
+    });
+
+    it('isActionNode on action node is true', () => {
+      const res = isActionNode(actionNode);
+      expect(res).toBeTruthy();
+    });
+
+    it('isActionNode on branch node is false', () => {
+      const res = isActionNode(branchNode);
+      expect(res).toBeFalsy();
+    });
+  });
+
   describe('delete transition orphan check', () => {
     it('returns true for single parent', () => {
       const value = willOrphanChild(

--- a/src/utils/builder.ts
+++ b/src/utils/builder.ts
@@ -99,6 +99,7 @@ export function exportPathway(pathway: Pathway, cpg: boolean): string {
     }
   };
 
+  /*
   const pathwayToExport: Pathway = {
     ...pathway,
     // Strip id from each precondition
@@ -157,8 +158,9 @@ export function exportPathway(pathway: Pathway, cpg: boolean): string {
             }))
     };
   });
+  */
 
-  return JSON.stringify(setNavigationalElm(pathwayToExport, elm), undefined, 2);
+  return JSON.stringify(setNavigationalElm(pathway, elm), undefined, 2);
 }
 
 function mergeElm(elm: ElmLibrary, additionalElm: ElmLibrary): void {
@@ -215,20 +217,20 @@ function getElmStatement(elm: ElmLibrary): ElmStatement {
 // TODO: possibly add more precondition methods
 export function addPrecondition(
   pathway: Pathway,
+  id: string,
   elementName: string,
   expected: string,
   cql: string
-): string {
-  const id = shortid.generate();
+): Pathway {
   const precondition: Precondition = {
     id: id,
     elementName: elementName,
     expected: expected,
     cql: cql
   };
-  pathway.preconditions.push(precondition);
-
-  return id;
+  return produce(pathway, (draftPathway: Pathway) => {
+    draftPathway.preconditions.push(precondition);
+  });
 }
 
 export function setNavigationalElm(pathway: Pathway, elm: object): Pathway {
@@ -405,30 +407,6 @@ export function setActionNodeElm(pathway: Pathway, nodeKey: string, elm: ElmLibr
     (draftPathway.nodes[nodeKey] as ActionNode).elm = elm;
     (draftPathway.nodes[nodeKey] as ActionNode).cql = getElmStatement(elm).name;
   });
-}
-
-// TODO: possibly add more action methods
-export function addAction(
-  pathway: Pathway,
-  key: string,
-  type: string,
-  description: string,
-  resource: MedicationRequest | ServiceRequest
-): string {
-  const id = shortid.generate();
-  const action = {
-    id: id,
-    type: type,
-    description: description,
-    resource: resource
-  };
-
-  const node = produce(pathway.nodes[key] as ActionNode, (draftState: ActionNode) => {
-    draftState.action.push(action);
-  });
-  pathway.nodes[key] = node;
-
-  return id;
 }
 
 export function getNodeType(node?: ActionNode | BranchNode | PathwayNode | null): string {

--- a/src/utils/builder.ts
+++ b/src/utils/builder.ts
@@ -9,16 +9,15 @@ import {
 } from 'pathways-model';
 import { ElmLibrary, ElmStatement } from 'elm-model';
 import shortid from 'shortid';
-import { MedicationRequest, ServiceRequest } from 'fhir-objects';
 import produce from 'immer';
 import { toCPG } from './cpg';
 import { Criteria } from 'criteria-model';
 
-export function createNewPathway(name: string, description?: string, pathwayId?: string): Pathway {
+export function createNewPathway(name: string, description: string, pathwayId?: string): Pathway {
   return {
     id: pathwayId ?? shortid.generate(),
     name: name,
-    description: description ?? '',
+    description: description,
     library: '',
     preconditions: [],
     nodes: {
@@ -48,8 +47,13 @@ export function downloadPathway(pathway: Pathway, cpg = false): void {
 }
 
 export function exportPathway(pathway: Pathway, cpg: boolean): string {
-  if (cpg) return JSON.stringify(toCPG(pathway), undefined, 2);
+  const elm = generateNavigationalElm(pathway);
+  const pathwayWithElm = setNavigationalElm(pathway, elm);
+  const pathwayToExport = cpg ? toCPG(pathwayWithElm) : pathwayWithElm;
+  return JSON.stringify(pathwayToExport, undefined, 2);
+}
 
+function generateNavigationalElm(pathway: Pathway): ElmLibrary {
   const elm: ElmLibrary = {
     library: {
       identifier: {
@@ -99,68 +103,32 @@ export function exportPathway(pathway: Pathway, cpg: boolean): string {
     }
   };
 
-  /*
-  const pathwayToExport: Pathway = {
-    ...pathway,
-    // Strip id from each precondition
-    preconditions: pathway.preconditions.map((precondition: Precondition) => ({
-      ...precondition,
-      id: undefined
-    })),
-    nodes: { ...pathway.nodes }
-  };
-
-  Object.keys(pathwayToExport.nodes).forEach((nodeKey: string) => {
+  Object.keys(pathway.nodes).forEach((nodeKey: string) => {
     const node = pathway.nodes[nodeKey];
-    if ('elm' in node && node.elm && node.key) {
+    if ('elm' in node && node.elm) {
       mergeElm(elm, node.elm);
       const elmStatement = produce(getElmStatement(node.elm), (draftElmStatement: ElmStatement) => {
-        // state.key is defined due to if statement above
-        // eslint-disable-next-line
-        draftElmStatement.name = node.key!;
+        draftElmStatement.name = node.key;
       });
       elm.library.statements.def.push(elmStatement);
     }
 
-    pathwayToExport.nodes[nodeKey] = {
-      ...pathwayToExport.nodes[nodeKey],
-      // Strip key from each node
-      key: undefined,
-      elm: undefined,
-      // Strip id from each node.transition
-      transitions: node.transitions.map((transition: Transition) => {
-        if (transition.condition?.elm) {
-          // Add tranistion.condition.elm to elm
-          mergeElm(elm, transition.condition.elm);
-          const elmStatement = produce(
-            getElmStatement(transition.condition.elm),
-            (draftElmStatement: ElmStatement) => {
-              draftElmStatement.name = transition.condition?.description ?? 'Unknown';
-            }
-          );
-          elm.library.statements.def.push(elmStatement);
-        }
-        return {
-          ...transition,
-          id: undefined,
-          condition: transition.condition
-            ? { ...transition.condition, elm: undefined, criteriaSource: undefined }
-            : undefined
-        };
-      }),
-      // Strip id from each node.action
-      action:
-        (node as ActionNode).action == null
-          ? undefined
-          : (node as ActionNode).action.map((action: Action) => ({
-              ...action,
-              id: undefined
-            }))
-    };
+    node.transitions.forEach((transition: Transition) => {
+      if (transition.condition?.elm) {
+        // Add tranistion.condition.elm to elm
+        mergeElm(elm, transition.condition.elm);
+        const elmStatement = produce(
+          getElmStatement(transition.condition.elm),
+          (draftElmStatement: ElmStatement) => {
+            draftElmStatement.name = transition.condition?.description ?? 'Unknown';
+          }
+        );
+        elm.library.statements.def.push(elmStatement);
+      }
+    });
   });
-  */
 
-  return JSON.stringify(setNavigationalElm(pathway, elm), undefined, 2);
+  return elm;
 }
 
 function mergeElm(elm: ElmLibrary, additionalElm: ElmLibrary): void {
@@ -261,7 +229,7 @@ export function createNode(key?: string): PathwayNode {
 
 export function addNode(pathway: Pathway, node: PathwayNode): Pathway {
   return produce(pathway, (draftPathway: Pathway) => {
-    draftPathway.nodes[node.key as string] = node;
+    draftPathway.nodes[node.key] = node;
   });
 }
 
@@ -269,7 +237,7 @@ export function addActionNode(pathway: Pathway): Pathway {
   const node = createNode();
   const newPathway = addNode(pathway, node);
 
-  return makeNodeAction(newPathway, node.key as string);
+  return makeNodeAction(newPathway, node.key);
 }
 
 export function setNodeLabel(pathway: Pathway, key: string, label: string): Pathway {
@@ -301,7 +269,7 @@ export function setNodeType(pathway: Pathway, nodeKey: string, nodeType: string)
           }
         }
       };
-      return setNodeAction(newPathway, nodeKey, [action]);
+      return setNodeAction(newPathway, nodeKey, action);
     case 'ServiceRequest':
       newPathway = makeNodeAction(pathway, nodeKey);
       action = {
@@ -321,7 +289,7 @@ export function setNodeType(pathway: Pathway, nodeKey: string, nodeType: string)
           }
         }
       };
-      return setNodeAction(newPathway, nodeKey, [action]);
+      return setNodeAction(newPathway, nodeKey, action);
     case 'CarePlan':
       newPathway = makeNodeAction(pathway, nodeKey);
       action = {
@@ -333,7 +301,7 @@ export function setNodeType(pathway: Pathway, nodeKey: string, nodeType: string)
           title: ''
         }
       };
-      return setNodeAction(newPathway, nodeKey, [action]);
+      return setNodeAction(newPathway, nodeKey, action);
     case 'Observation':
       return makeNodeBranch(pathway, nodeKey);
     default:
@@ -342,7 +310,7 @@ export function setNodeType(pathway: Pathway, nodeKey: string, nodeType: string)
   }
 }
 
-export function setNodeAction(pathway: Pathway, key: string, action: Action[]): Pathway {
+export function setNodeAction(pathway: Pathway, key: string, action: Action): Pathway {
   return produce(pathway, (draftPathway: Pathway) => {
     (draftPathway.nodes[key] as ActionNode).action = action;
   });
@@ -494,53 +462,35 @@ export function setTransitionConditionElm(
   });
 }
 
-export function setActionType(
-  pathway: Pathway,
-  nodeKey: string,
-  actionId: string,
-  type: string
-): Pathway {
-  return produce(pathway, (draftPathway: Pathway) => {
-    if ((draftPathway.nodes[nodeKey] as ActionNode).action) {
-      const action = (draftPathway.nodes[nodeKey] as ActionNode).action.find(
-        (action: Action) => action.id === actionId
-      );
-      if (action) action.type = type;
+export function setActionCode(action: Action, code: string): Action {
+  return produce(action, (draftAction: Action) => {
+    if (draftAction.resource.medicationCodeableConcept) {
+      draftAction.resource.medicationCodeableConcept.coding[0].code = code;
+    } else {
+      draftAction.resource.code.coding[0].code = code;
     }
   });
 }
 
-export function setActionDescription(
-  pathway: Pathway,
-  nodeKey: string,
-  actionId: string,
-  description: string
-): Pathway {
-  return produce(pathway, (draftPathway: Pathway) => {
-    const node = (draftPathway.nodes[nodeKey] as ActionNode).action;
-
-    if (node) {
-      const action = node.find((action: Action) => action.id === actionId);
-      if (action) {
-        action.description = description;
-      }
+export function setActionCodeSystem(action: Action, codeSystem: string): Action {
+  return produce(action, (draftAction: Action) => {
+    if (draftAction.resource.medicationCodeableConcept) {
+      draftAction.resource.medicationCodeableConcept.coding[0].system = codeSystem;
+    } else {
+      draftAction.resource.code.coding[0].system = codeSystem;
     }
   });
 }
 
-export function setActionResource(
-  pathway: Pathway,
-  nodeKey: string,
-  actionId: string,
-  resource: MedicationRequest | ServiceRequest
-): Pathway {
-  return produce(pathway, (draftPathway: Pathway) => {
-    if ((draftPathway.nodes[nodeKey] as ActionNode).action) {
-      const action = (draftPathway.nodes[nodeKey] as ActionNode).action.find(
-        (action: Action) => action.id === actionId
-      );
-      if (action) action.resource = resource;
-    }
+export function setActionDescription(action: Action, description: string): Action {
+  return produce(action, (draftaction: Action) => {
+    draftaction.description = description;
+  });
+}
+
+export function setActionTitle(action: Action, title: string): Action {
+  return produce(action, (draftaction: Action) => {
+    draftaction.resource.title = title;
   });
 }
 
@@ -562,7 +512,6 @@ export function makeNodeAction(pathway: Pathway, nodeKey: string): Pathway {
 
     if (node.cql === undefined && node.action === undefined) {
       node.cql = '';
-      node.action = [];
       node.nodeTypeIsUndefined = undefined;
     }
 
@@ -579,7 +528,7 @@ export function makeNodeBranch(pathway: Pathway, nodeKey: string): Pathway {
     if (
       node.cql !== undefined ||
       node.elm !== undefined ||
-      node.action !== undefined ||
+      node.action !== null ||
       node.nodeTypeIsUndefined !== undefined
     ) {
       delete node.cql;
@@ -646,12 +595,6 @@ export function createCQL(action: Action, nodeKey: string): string {
 /*
 Remove Element Function
 */
-export function removePathwayDescription(pathway: Pathway): Pathway {
-  return produce(pathway, (draftPathway: Pathway) => {
-    delete draftPathway.description;
-  });
-}
-
 export function removePrecondition(pathway: Pathway, id: string): Pathway {
   return produce(pathway, (draftPathway: Pathway) => {
     const preconditions = draftPathway.preconditions.filter(
@@ -712,16 +655,5 @@ export function removeTransition(
       (transition: Transition) => transition.transition !== childNodeKey
     );
     draftPathway.nodes[parentNodeKey].transitions = transitions;
-  });
-}
-
-export function removeAction(pathway: Pathway, nodeKey: string, actionId: string): Pathway {
-  return produce(pathway, (draftPathway: Pathway) => {
-    if ((draftPathway.nodes[nodeKey] as ActionNode).action) {
-      const actions = (draftPathway.nodes[nodeKey] as ActionNode).action.filter(
-        (action: Action) => action.id !== actionId
-      );
-      (draftPathway.nodes[nodeKey] as ActionNode).action = actions;
-    }
   });
 }

--- a/src/utils/builder.ts
+++ b/src/utils/builder.ts
@@ -233,13 +233,6 @@ export function addNode(pathway: Pathway, node: PathwayNode): Pathway {
   });
 }
 
-export function addActionNode(pathway: Pathway): Pathway {
-  const node = createNode();
-  const newPathway = addNode(pathway, node);
-
-  return makeNodeAction(newPathway, node.key);
-}
-
 export function setNodeLabel(pathway: Pathway, key: string, label: string): Pathway {
   return produce(pathway, (draftPathway: Pathway) => {
     draftPathway.nodes[key].label = label;
@@ -528,7 +521,7 @@ export function makeNodeBranch(pathway: Pathway, nodeKey: string): Pathway {
     if (
       node.cql !== undefined ||
       node.elm !== undefined ||
-      node.action !== null ||
+      node.action !== undefined ||
       node.nodeTypeIsUndefined !== undefined
     ) {
       delete node.cql;

--- a/src/utils/cpg.ts
+++ b/src/utils/cpg.ts
@@ -199,14 +199,14 @@ export function toCPG(pathway: Pathway): Bundle {
   const cpgStrategy = createPlanDefinition(
     uuidv4(),
     pathway.name,
-    pathway.description ?? `Pathway For: ${pathway.name}`,
+    pathway.description,
     'strategy',
     library.id
   );
 
   Object.keys(pathway.nodes).forEach(key => {
     const node = pathway.nodes[key];
-    if (isActionNode(node) && node.key) {
+    if (isActionNode(node) && node.key && node.action) {
       const description = `Represents an action for ${node.label}`;
       const cpgRecommendation = createPlanDefinition(
         uuidv4(),
@@ -232,16 +232,15 @@ export function toCPG(pathway: Pathway): Bundle {
           cpgStrategyAction.condition?.push(condition);
         }
       });
-      node.action.forEach(action => {
-        const cpgActivityDefinition = createActivityDefinition(action);
-        const cpgRecommendationAction = createAction(
-          action.id ?? uuidv4(),
-          action.description,
-          cpgActivityDefinition.id
-        );
-        cpgRecommendation.action.push(cpgRecommendationAction);
-        bundle.entry.push(createBundleEntry(cpgActivityDefinition));
-      });
+      const action = node.action;
+      const cpgActivityDefinition = createActivityDefinition(action);
+      const cpgRecommendationAction = createAction(
+        action.id,
+        action.description,
+        cpgActivityDefinition.id
+      );
+      cpgRecommendation.action.push(cpgRecommendationAction);
+      bundle.entry.push(createBundleEntry(cpgActivityDefinition));
       cpgStrategy.action.push(cpgStrategyAction);
       bundle.entry.push(createBundleEntry(cpgRecommendation));
     }

--- a/src/utils/nodeUtils.ts
+++ b/src/utils/nodeUtils.ts
@@ -3,7 +3,7 @@ import { History } from 'history';
 
 export function isActionNode(node: PathwayNode): node is ActionNode {
   const { action } = node as ActionNode;
-  return action !== undefined;
+  return action !== null;
 }
 
 export function isBranchNode(node: PathwayNode): boolean {

--- a/src/utils/nodeUtils.ts
+++ b/src/utils/nodeUtils.ts
@@ -3,7 +3,7 @@ import { History } from 'history';
 
 export function isActionNode(node: PathwayNode): node is ActionNode {
   const { action } = node as ActionNode;
-  return action !== null;
+  return action !== undefined;
 }
 
 export function isBranchNode(node: PathwayNode): boolean {


### PR DESCRIPTION
While working on the CPG updates I ran into issues with the data model so I decided to pull [PATHWAYS-338](https://jira.mitre.org/browse/PATHWAYS-338) in. I updated the following in the data model:

- `Pathway.description` is now required
- `Precondition.id` is now required
- `PathwayNode.key` is now required
- `ActionNode.action` is now a single item instead of a list
- `Action.id` is now required
- `Transition.id` is now required

I still need to figure out what to do for the export (hence the mergeElm lint error) which strips these ids away but its in a good enough state for people to start looking at to make sure I didn't miss anything.