### PR TITLE
Undo

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react": "^16.10.1",
     "react-dom": "^16.10.1",
     "react-fontawesome": "^1.6.1",
+    "react-hot-keys": "^2.6.0",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.2.0",
     "react-select": "^3.0.8",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "semantic-ui-react": "^0.88.2",
     "shortid": "^2.2.15",
     "typescript": "^3.7.4",
+    "use-undo": "^1.0.3",
     "uuid": "^8.3.0"
   },
   "devDependencies": {

--- a/public/static/pathways/index.html
+++ b/public/static/pathways/index.html
@@ -1,5 +1,6 @@
 [
     "her2_pathway.json",
     "neoadjuvant_pathway.json",
-    "sample_pathway.json"
+    "sample_pathway.json",
+    "new_pathway.json"
 ]

--- a/public/static/pathways/new_pathway.json
+++ b/public/static/pathways/new_pathway.json
@@ -1,0 +1,14 @@
+{
+    "id": "new_pathway",
+    "name": "New Pathway",
+    "description": "A new pathway",
+    "library": "mCODE_Library.cql",
+    "preconditions": [],
+    "nodes": {
+      "Start": {
+        "key": "Start",
+        "label": "Start",
+        "transitions": []
+      }
+    }
+  }

--- a/public/static/pathways/new_pathway.json
+++ b/public/static/pathways/new_pathway.json
@@ -8,6 +8,7 @@
       "Start": {
         "key": "Start",
         "label": "Start",
+        "type": "start",
         "transitions": []
       }
     }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -21,10 +21,10 @@ const App: FC = () => {
   return (
     <ThemeProvider theme="light">
       <UserProvider>
-        <CurrentPathwayProvider>
-          <CriteriaProvider>
-            <PathwaysProvider>
-              <CurrentNodeProvider>
+        <CriteriaProvider>
+          <PathwaysProvider>
+            <CurrentNodeProvider>
+              <CurrentPathwayProvider>
                 <SnackbarProvider>
                   <CurrentCriteriaProvider>
                     <CriteriaBuilderProvider>
@@ -50,10 +50,10 @@ const App: FC = () => {
                     </CriteriaBuilderProvider>
                   </CurrentCriteriaProvider>
                 </SnackbarProvider>
-              </CurrentNodeProvider>
-            </PathwaysProvider>
-          </CriteriaProvider>
-        </CurrentPathwayProvider>
+              </CurrentPathwayProvider>
+            </CurrentNodeProvider>
+          </PathwaysProvider>
+        </CriteriaProvider>
       </UserProvider>
     </ThemeProvider>
   );

--- a/src/components/BuilderRoute.tsx
+++ b/src/components/BuilderRoute.tsx
@@ -9,7 +9,7 @@ import { useCurrentNodeContext } from './CurrentNodeProvider';
 const BuilderRoute: FC = () => {
   const { id, nodeId } = useParams();
   const { pathways } = usePathwaysContext();
-  const { setPathway } = useCurrentPathwayContext();
+  const { pathway: currentPathway, setPathway, resetPathway } = useCurrentPathwayContext();
   const { setCurrentNode } = useCurrentNodeContext();
   const pathwayId = decodeURIComponent(id);
   const pathwayIndex = useMemo(() => pathways.findIndex(pathway => pathway.id === pathwayId), [
@@ -20,8 +20,9 @@ const BuilderRoute: FC = () => {
   const currentNode = pathway?.nodes?.[decodeURIComponent(nodeId)];
 
   useEffect(() => {
-    setPathway(pathway);
-  }, [pathway, setPathway]);
+    if (currentPathway?.id === pathway?.id) setPathway(pathway);
+    else resetPathway(pathway);
+  }, [pathway, setPathway, resetPathway]);
 
   useEffect(() => {
     setCurrentNode(currentNode);

--- a/src/components/BuilderRoute.tsx
+++ b/src/components/BuilderRoute.tsx
@@ -9,7 +9,7 @@ import { useCurrentNodeContext } from './CurrentNodeProvider';
 const BuilderRoute: FC = () => {
   const { id, nodeId } = useParams();
   const { pathways } = usePathwaysContext();
-  const { pathwayRef, setPathway, resetPathway } = useCurrentPathwayContext();
+  const { pathwayRef, setCurrentPathway, resetCurrentPathway } = useCurrentPathwayContext();
   const { setCurrentNode } = useCurrentNodeContext();
   const pathwayId = decodeURIComponent(id);
   const pathwayIndex = useMemo(() => pathways.findIndex(pathway => pathway.id === pathwayId), [
@@ -20,9 +20,9 @@ const BuilderRoute: FC = () => {
   const currentNodeId = decodeURIComponent(nodeId);
 
   useEffect(() => {
-    if (pathway && pathwayRef?.current?.id === pathway.id) setPathway(pathway);
-    else if (pathway) resetPathway(pathway);
-  }, [pathway, pathwayRef, setCurrentNode, setPathway, resetPathway]); // eslint-disable-line
+    if (pathway && pathwayRef?.current?.id === pathway.id) setCurrentPathway(pathway);
+    else if (pathway) resetCurrentPathway(pathway);
+  }, [pathway, pathwayRef, setCurrentNode, setCurrentPathway, resetCurrentPathway]);
 
   useEffect(() => {
     if (pathwayRef.current?.nodes[currentNodeId])

--- a/src/components/BuilderRoute.tsx
+++ b/src/components/BuilderRoute.tsx
@@ -9,12 +9,7 @@ import { useCurrentNodeContext } from './CurrentNodeProvider';
 const BuilderRoute: FC = () => {
   const { id, nodeId } = useParams();
   const { pathways } = usePathwaysContext();
-  const {
-    pathway: currentPathway,
-    pathwayRef,
-    setPathway,
-    resetPathway
-  } = useCurrentPathwayContext();
+  const { pathwayRef, setPathway, resetPathway } = useCurrentPathwayContext();
   const { setCurrentNode } = useCurrentNodeContext();
   const pathwayId = decodeURIComponent(id);
   const pathwayIndex = useMemo(() => pathways.findIndex(pathway => pathway.id === pathwayId), [

--- a/src/components/BuilderRoute.tsx
+++ b/src/components/BuilderRoute.tsx
@@ -9,7 +9,7 @@ import { useCurrentNodeContext } from './CurrentNodeProvider';
 const BuilderRoute: FC = () => {
   const { id, nodeId } = useParams();
   const { pathways } = usePathwaysContext();
-  const { pathway: currentPathway, setPathway, resetPathway } = useCurrentPathwayContext();
+  const { pathwayRef, setPathway, resetPathway } = useCurrentPathwayContext();
   const { setCurrentNode } = useCurrentNodeContext();
   const pathwayId = decodeURIComponent(id);
   const pathwayIndex = useMemo(() => pathways.findIndex(pathway => pathway.id === pathwayId), [
@@ -20,9 +20,9 @@ const BuilderRoute: FC = () => {
   const currentNode = pathway?.nodes?.[decodeURIComponent(nodeId)];
 
   useEffect(() => {
-    if (currentPathway?.id === pathway?.id) setPathway(pathway);
+    if (pathwayRef?.current?.id === pathway?.id) setPathway(pathway);
     else resetPathway(pathway);
-  }, [pathway, setPathway, resetPathway]);
+  }, [pathway, pathwayRef, setPathway, resetPathway]);
 
   useEffect(() => {
     setCurrentNode(currentNode);

--- a/src/components/BuilderRoute.tsx
+++ b/src/components/BuilderRoute.tsx
@@ -9,7 +9,12 @@ import { useCurrentNodeContext } from './CurrentNodeProvider';
 const BuilderRoute: FC = () => {
   const { id, nodeId } = useParams();
   const { pathways } = usePathwaysContext();
-  const { pathwayRef, setPathway, resetPathway } = useCurrentPathwayContext();
+  const {
+    pathway: currentPathway,
+    pathwayRef,
+    setPathway,
+    resetPathway
+  } = useCurrentPathwayContext();
   const { setCurrentNode } = useCurrentNodeContext();
   const pathwayId = decodeURIComponent(id);
   const pathwayIndex = useMemo(() => pathways.findIndex(pathway => pathway.id === pathwayId), [
@@ -20,9 +25,8 @@ const BuilderRoute: FC = () => {
   const currentNodeId = decodeURIComponent(nodeId);
 
   useEffect(() => {
-    if (pathwayRef.current) setCurrentNode(pathwayRef.current.nodes[currentNodeId]);
-    if (pathwayRef?.current?.id === pathway?.id) setPathway(pathway);
-    else resetPathway(pathway);
+    if (pathway && pathwayRef?.current?.id === pathway.id) setPathway(pathway);
+    else if (pathway) resetPathway(pathway);
   }, [pathway, pathwayRef, setCurrentNode, setPathway, resetPathway]); // eslint-disable-line
 
   useEffect(() => {

--- a/src/components/BuilderRoute.tsx
+++ b/src/components/BuilderRoute.tsx
@@ -1,4 +1,4 @@
-import React, { FC, memo, useMemo, useEffect, useState } from 'react';
+import React, { FC, memo, useMemo, useEffect } from 'react';
 import { Redirect, useParams } from 'react-router-dom';
 
 import Builder from 'components/Builder';
@@ -23,7 +23,7 @@ const BuilderRoute: FC = () => {
     if (pathwayRef.current) setCurrentNode(pathwayRef.current.nodes[currentNodeId]);
     if (pathwayRef?.current?.id === pathway?.id) setPathway(pathway);
     else resetPathway(pathway);
-  }, [pathway, pathwayRef, setPathway, resetPathway]);
+  }, [pathway, pathwayRef, setCurrentNode, setPathway, resetPathway]); // eslint-disable-line
 
   useEffect(() => {
     if (pathwayRef.current?.nodes[currentNodeId])

--- a/src/components/BuilderRoute.tsx
+++ b/src/components/BuilderRoute.tsx
@@ -1,4 +1,4 @@
-import React, { FC, memo, useMemo, useEffect } from 'react';
+import React, { FC, memo, useMemo, useEffect, useState } from 'react';
 import { Redirect, useParams } from 'react-router-dom';
 
 import Builder from 'components/Builder';
@@ -17,19 +17,23 @@ const BuilderRoute: FC = () => {
     pathways
   ]);
   const pathway = pathways[pathwayIndex];
-  const currentNode = pathway?.nodes?.[decodeURIComponent(nodeId)];
+  const currentNodeId = decodeURIComponent(nodeId);
 
   useEffect(() => {
+    if (pathwayRef.current) setCurrentNode(pathwayRef.current.nodes[currentNodeId]);
     if (pathwayRef?.current?.id === pathway?.id) setPathway(pathway);
     else resetPathway(pathway);
   }, [pathway, pathwayRef, setPathway, resetPathway]);
 
   useEffect(() => {
-    setCurrentNode(currentNode);
-  }, [currentNode, setCurrentNode]);
+    if (pathwayRef.current?.nodes[currentNodeId])
+      setCurrentNode(pathwayRef.current.nodes[currentNodeId]);
+    else if (pathway?.nodes[currentNodeId]) setCurrentNode(pathway.nodes[currentNodeId]);
+    else if (pathway) setCurrentNode(pathway.nodes['Start']);
+  }, [pathway, pathwayRef, currentNodeId, setCurrentNode]);
 
   if (pathway == null) return null;
-  if (currentNode == null) return <Redirect to={`/builder/${id}/node/Start`} />;
+  if (!currentNodeId) return <Redirect to={`/builder/${id}/node/Start`} />;
 
   return <Builder />;
 };

--- a/src/components/CurrentPathwayProvider.tsx
+++ b/src/components/CurrentPathwayProvider.tsx
@@ -55,7 +55,6 @@ export const CurrentPathwayProvider: FC<CurrentPathwayProviderProps> = memo(({ c
 
   const resetPathway = useCallback(
     (value: Pathway) => {
-      console.log('resetPathway');
       _resetPathway(value);
     },
     [_resetPathway]
@@ -63,7 +62,6 @@ export const CurrentPathwayProvider: FC<CurrentPathwayProviderProps> = memo(({ c
 
   const setPathway = useCallback(
     (value: Pathway) => {
-      console.log('setPathway');
       _setPathway(value);
     },
     [_setPathway]

--- a/src/components/CurrentPathwayProvider.tsx
+++ b/src/components/CurrentPathwayProvider.tsx
@@ -20,8 +20,8 @@ interface CurrentPathwayContextInterface {
   canRedoPathway: boolean;
   undoPathway: () => void;
   redoPathway: () => void;
-  resetPathway: (value: Pathway) => void;
-  setPathway: (value: Pathway) => void;
+  resetCurrentPathway: (value: Pathway) => void;
+  setCurrentPathway: (value: Pathway) => void;
 }
 
 export const CurrentPathwayContext = createContext<CurrentPathwayContextInterface>(
@@ -53,14 +53,14 @@ export const CurrentPathwayProvider: FC<CurrentPathwayProviderProps> = memo(({ c
     _redoPathway();
   }, [_redoPathway]);
 
-  const resetPathway = useCallback(
+  const resetCurrentPathway = useCallback(
     (value: Pathway) => {
       _resetPathway(value);
     },
     [_resetPathway]
   );
 
-  const setPathway = useCallback(
+  const setCurrentPathway = useCallback(
     (value: Pathway) => {
       _setPathway(value);
     },
@@ -80,12 +80,12 @@ export const CurrentPathwayProvider: FC<CurrentPathwayProviderProps> = memo(({ c
         canRedoPathway,
         undoPathway,
         redoPathway,
-        resetPathway,
-        setPathway
+        resetCurrentPathway,
+        setCurrentPathway
       }}
     >
-      <HotKeys keyName="control+z" onKeyDown={undoPathway}>
-        <HotKeys keyName="control+y" onKeyDown={redoPathway}>
+      <HotKeys keyName="control+z,command+z" onKeyDown={undoPathway}>
+        <HotKeys keyName="control+y,command+y" onKeyDown={redoPathway}>
           {children}
         </HotKeys>
       </HotKeys>

--- a/src/components/CurrentPathwayProvider.tsx
+++ b/src/components/CurrentPathwayProvider.tsx
@@ -8,11 +8,15 @@ import React, {
   MutableRefObject
 } from 'react';
 import { Pathway } from 'pathways-model';
-import useRefState from 'utils/useRefState';
+import useRefUndoState from 'utils/useRefUndoState';
 
 interface CurrentPathwayContextInterface {
   pathway: Pathway | null;
   pathwayRef: MutableRefObject<Pathway | null>;
+  canUndoPathway: boolean;
+  canRedoPathway: boolean;
+  undoPathway: () => void;
+  redoPathway: () => void;
   setPathway: (value: Pathway) => void;
 }
 
@@ -25,7 +29,19 @@ interface CurrentPathwayProviderProps {
 }
 
 export const CurrentPathwayProvider: FC<CurrentPathwayProviderProps> = memo(({ children }) => {
-  const [pathway, pathwayRef, _setPathway] = useRefState<Pathway | null>(null);
+  const [pathway, pathwayRef, canUndoPathway, canRedoPathway, _undoPathway, _redoPathway, _setPathway] = useRefUndoState<Pathway | null>(null);
+
+  const undoPathway = useCallback(() => {
+      _undoPathway();
+    },
+    [_undoPathway]
+  );
+
+  const redoPathway = useCallback(() => {
+      _redoPathway();
+    },
+    [_redoPathway]
+  );
 
   const setPathway = useCallback(
     (value: Pathway) => {
@@ -35,7 +51,7 @@ export const CurrentPathwayProvider: FC<CurrentPathwayProviderProps> = memo(({ c
   );
 
   return (
-    <CurrentPathwayContext.Provider value={{ pathway, pathwayRef, setPathway }}>
+    <CurrentPathwayContext.Provider value={{ pathway, pathwayRef, canUndoPathway, canRedoPathway, undoPathway, redoPathway, setPathway }}>
       {children}
     </CurrentPathwayContext.Provider>
   );

--- a/src/components/CurrentPathwayProvider.tsx
+++ b/src/components/CurrentPathwayProvider.tsx
@@ -43,14 +43,14 @@ export const CurrentPathwayProvider: FC<CurrentPathwayProviderProps> = memo(({ c
     _resetPathway,
     _setPathway
   ] = useRefUndoState<Pathway | null>(null);
-  const { currentNode, setCurrentNode } = useCurrentNodeContext();
+  const { currentNodeRef, setCurrentNode } = useCurrentNodeContext();
   const { updatePathway } = usePathwaysContext();
 
   const undoPathway = useCallback(() => {
     _undoPathway();
     // Update Pathways Context
-    if (pathway) updatePathway(pathway);
-  }, [_undoPathway]);
+    if (pathwayRef.current) updatePathway(pathwayRef.current);
+  }, [pathwayRef, _undoPathway]);
 
   const redoPathway = useCallback(() => {
     _redoPathway();
@@ -73,19 +73,21 @@ export const CurrentPathwayProvider: FC<CurrentPathwayProviderProps> = memo(({ c
   // Update CurrentNode based on undo
   useEffect(() => {
     let newCurrentNodeKey;
-    if (pathway && currentNode && Object.keys(pathway.nodes).includes(currentNode.key)) {
-      // Update current node to use the latest value of the node from the pathway
-      newCurrentNodeKey = currentNode.key;
-    } else if (pathway && currentNode && !Object.keys(pathway.nodes).includes(currentNode.key)) {
-      // Current node is set but it has been deleted and default to start
-      newCurrentNodeKey = 'Start';
+    if (pathwayRef.current && currentNodeRef.current) {
+      if (Object.keys(pathwayRef.current.nodes).includes(currentNodeRef.current.key)) {
+        // Update current node to use the latest value of the node from the pathway
+        newCurrentNodeKey = currentNodeRef.current.key;
+      } else if (!Object.keys(pathwayRef.current.nodes).includes(currentNodeRef.current.key)) {
+        // Current node is set but it has been deleted and default to start
+        newCurrentNodeKey = 'Start';
+      }
     }
 
-    if (pathway && newCurrentNodeKey) {
-      setCurrentNode(pathway?.nodes[newCurrentNodeKey]);
+    if (pathwayRef.current && newCurrentNodeKey) {
+      setCurrentNode(pathwayRef.current.nodes[newCurrentNodeKey]);
       // redirect(pathway.id, newCurrentNodeKey, history);
     }
-  }, [pathway, currentNode, setCurrentNode]);
+  }, [pathwayRef, currentNodeRef, setCurrentNode]);
 
   return (
     <CurrentPathwayContext.Provider

--- a/src/components/CurrentPathwayProvider.tsx
+++ b/src/components/CurrentPathwayProvider.tsx
@@ -11,6 +11,7 @@ import React, {
 import { Pathway } from 'pathways-model';
 import useRefUndoState from 'utils/useRefUndoState';
 import { usePathwaysContext } from './PathwaysProvider';
+import HotKeys from 'react-hot-keys';
 
 interface CurrentPathwayContextInterface {
   pathway: Pathway | null;
@@ -54,6 +55,7 @@ export const CurrentPathwayProvider: FC<CurrentPathwayProviderProps> = memo(({ c
 
   const resetPathway = useCallback(
     (value: Pathway) => {
+      console.log('resetPathway');
       _resetPathway(value);
     },
     [_resetPathway]
@@ -61,6 +63,7 @@ export const CurrentPathwayProvider: FC<CurrentPathwayProviderProps> = memo(({ c
 
   const setPathway = useCallback(
     (value: Pathway) => {
+      console.log('setPathway');
       _setPathway(value);
     },
     [_setPathway]
@@ -69,30 +72,6 @@ export const CurrentPathwayProvider: FC<CurrentPathwayProviderProps> = memo(({ c
   useEffect(() => {
     if (pathway) updatePathway(pathway);
   }, [pathway, updatePathway]);
-
-  // // Update CurrentNode based on undo
-  // useEffect(() => {
-  //   let newCurrentNodeKey;
-  //   if (pathway && currentNodeRef.current) {
-  //     if (Object.keys(pathway.nodes).includes(currentNodeRef.current.key)) {
-  //       // Update current node to use the latest value of the node from the pathway
-  //       newCurrentNodeKey = currentNodeRef.current.key;
-  //     } else if (!Object.keys(pathway.nodes).includes(currentNodeRef.current.key)) {
-  //       // Current node is set but it has been deleted and default to start
-  //       newCurrentNodeKey = 'Start';
-  //     }
-  //   }
-
-  //   console.log('Updating based on undo');
-  //   console.log('oldCurrentNodeKey:' + currentNodeRef.current?.key);
-  //   console.log('newCurrentNodeKey: ' + newCurrentNodeKey);
-  //   console.log(pathway);
-  //   if (pathway && newCurrentNodeKey) {
-  //     setCurrentNode(pathway.nodes[newCurrentNodeKey]);
-  //     // updatePathway(pathway);
-  //     // redirect(pathway.id, newCurrentNodeKey, history);
-  //   }
-  // }, [pathway, currentNodeRef, setCurrentNode, updatePathway]);
 
   return (
     <CurrentPathwayContext.Provider
@@ -107,7 +86,11 @@ export const CurrentPathwayProvider: FC<CurrentPathwayProviderProps> = memo(({ c
         setPathway
       }}
     >
-      {children}
+      <HotKeys keyName="control+z" onKeyDown={undoPathway}>
+        <HotKeys keyName="control+y" onKeyDown={redoPathway}>
+          {children}
+        </HotKeys>
+      </HotKeys>
     </CurrentPathwayContext.Provider>
   );
 });

--- a/src/components/CurrentPathwayProvider.tsx
+++ b/src/components/CurrentPathwayProvider.tsx
@@ -56,14 +56,14 @@ export const CurrentPathwayProvider: FC<CurrentPathwayProviderProps> = memo(({ c
     (value: Pathway) => {
       _resetPathway(value);
     },
-    [_resetPathway, updatePathway]
+    [_resetPathway]
   );
 
   const setPathway = useCallback(
     (value: Pathway) => {
       _setPathway(value);
     },
-    [_setPathway, updatePathway]
+    [_setPathway]
   );
 
   useEffect(() => {

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -12,8 +12,13 @@ import ExportMenu from 'components/elements/ExportMenu';
 const Navigation: FC = () => {
   const { resetCurrentCriteria } = useCurrentCriteriaContext();
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const { pathway } = useCurrentPathwayContext();
-  const { canUndoPathway, canRedoPathway, undoPathway, redoPathway } = useCurrentPathwayContext();
+  const {
+    pathway,
+    canUndoPathway,
+    canRedoPathway,
+    undoPathway,
+    redoPathway
+  } = useCurrentPathwayContext();
   const styles = useStyles();
   const history = useHistory();
 

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -45,14 +45,14 @@ const Navigation: FC = () => {
         <span className={styles.pathwayName}>{pathway?.name}</span>
       </div>
       <div>
-        <Tooltip title="Undo">
+        <Tooltip placement="top" title="Undo" arrow>
           <span>
             <IconButton onClick={undoPathway} disabled={!canUndoPathway} aria-label="undo">
               <FontAwesomeIcon icon={faUndo} className={styles.navigationIcons} />
             </IconButton>
           </span>
         </Tooltip>
-        <Tooltip title="Redo">
+        <Tooltip placement="top" title="Redo" arrow>
           <span>
             <IconButton onClick={redoPathway} disabled={!canRedoPathway} aria-label="redo">
               <FontAwesomeIcon icon={faRedo} className={styles.navigationIcons} />

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -35,8 +35,6 @@ const Navigation: FC = () => {
     history.push('/');
   }, [history, resetCurrentCriteria]);
 
-  const undoTooltipText = canUndoPathway ? 'Undo' : 'Undo (disabled)';
-  const redoTooltipText = canRedoPathway ? 'Redo' : 'Redo (disabled)';
   return (
     <nav className={styles.root}>
       <div>
@@ -47,14 +45,14 @@ const Navigation: FC = () => {
         <span className={styles.pathwayName}>{pathway?.name}</span>
       </div>
       <div>
-        <Tooltip title={undoTooltipText}>
+        <Tooltip title="Undo">
           <span>
             <IconButton onClick={undoPathway} disabled={!canUndoPathway} aria-label="undo">
               <FontAwesomeIcon icon={faUndo} className={styles.navigationIcons} />
             </IconButton>
           </span>
         </Tooltip>
-        <Tooltip title={redoTooltipText}>
+        <Tooltip title="Redo">
           <span>
             <IconButton onClick={redoPathway} disabled={!canRedoPathway} aria-label="redo">
               <FontAwesomeIcon icon={faRedo} className={styles.navigationIcons} />

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -2,7 +2,7 @@ import React, { FC, useCallback, useState, MouseEvent } from 'react';
 import { useHistory } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faChevronLeft, faEllipsisH, faRedo, faUndo } from '@fortawesome/free-solid-svg-icons';
-import { IconButton } from '@material-ui/core';
+import { IconButton, Tooltip } from '@material-ui/core';
 
 import { useCurrentCriteriaContext } from 'components/CurrentCriteriaProvider';
 import useStyles from './styles';
@@ -35,6 +35,8 @@ const Navigation: FC = () => {
     history.push('/');
   }, [history, resetCurrentCriteria]);
 
+  const undoTooltipText = canUndoPathway ? 'Undo' : 'Undo (disabled)';
+  const redoTooltipText = canRedoPathway ? 'Redo' : 'Redo (disabled)';
   return (
     <nav className={styles.root}>
       <div>
@@ -45,12 +47,20 @@ const Navigation: FC = () => {
         <span className={styles.pathwayName}>{pathway?.name}</span>
       </div>
       <div>
-        <IconButton onClick={undoPathway} disabled={!canUndoPathway} aria-label="undo">
-          <FontAwesomeIcon icon={faUndo} className={styles.navigationIcons} />
-        </IconButton>
-        <IconButton onClick={redoPathway} disabled={!canRedoPathway} aria-label="redo">
-          <FontAwesomeIcon icon={faRedo} className={styles.navigationIcons} />
-        </IconButton>
+        <Tooltip title={undoTooltipText}>
+          <span>
+            <IconButton onClick={undoPathway} disabled={!canUndoPathway} aria-label="undo">
+              <FontAwesomeIcon icon={faUndo} className={styles.navigationIcons} />
+            </IconButton>
+          </span>
+        </Tooltip>
+        <Tooltip title={redoTooltipText}>
+          <span>
+            <IconButton onClick={redoPathway} disabled={!canRedoPathway} aria-label="redo">
+              <FontAwesomeIcon icon={faRedo} className={styles.navigationIcons} />
+            </IconButton>
+          </span>
+        </Tooltip>
         <IconButton onClick={openMenu} aria-controls="pathway-options-menu" aria-haspopup="true">
           <FontAwesomeIcon icon={faEllipsisH} className={styles.navigationIcons} />
         </IconButton>

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useCallback, useState, MouseEvent } from 'react';
 import { useHistory } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faChevronLeft, faEllipsisH } from '@fortawesome/free-solid-svg-icons';
+import { faChevronLeft, faEllipsisH, faRedo, faUndo } from '@fortawesome/free-solid-svg-icons';
 import { IconButton } from '@material-ui/core';
 
 import { useCurrentCriteriaContext } from 'components/CurrentCriteriaProvider';
@@ -13,6 +13,7 @@ const Navigation: FC = () => {
   const { resetCurrentCriteria } = useCurrentCriteriaContext();
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const { pathway } = useCurrentPathwayContext();
+  const { canUndoPathway, canRedoPathway, undoPathway, redoPathway } = useCurrentPathwayContext();
   const styles = useStyles();
   const history = useHistory();
 
@@ -38,10 +39,18 @@ const Navigation: FC = () => {
 
         <span className={styles.pathwayName}>{pathway?.name}</span>
       </div>
-      <IconButton onClick={openMenu} aria-controls="pathway-options-menu" aria-haspopup="true">
-        <FontAwesomeIcon icon={faEllipsisH} className={styles.navigationIcons} />
-      </IconButton>
-      <ExportMenu anchorEl={anchorEl} closeMenu={closeMenu} />
+      <div>
+        <IconButton onClick={undoPathway} disabled={!canUndoPathway} aria-label="undo">
+          <FontAwesomeIcon icon={faUndo} className={styles.navigationIcons} />
+        </IconButton>
+        <IconButton onClick={redoPathway} disabled={!canRedoPathway} aria-label="redo">
+          <FontAwesomeIcon icon={faRedo} className={styles.navigationIcons} />
+        </IconButton>
+        <IconButton onClick={openMenu} aria-controls="pathway-options-menu" aria-haspopup="true">
+          <FontAwesomeIcon icon={faEllipsisH} className={styles.navigationIcons} />
+        </IconButton>
+        <ExportMenu anchorEl={anchorEl} closeMenu={closeMenu} />
+      </div>
     </nav>
   );
 };

--- a/src/components/Navigation/styles.tsx
+++ b/src/components/Navigation/styles.tsx
@@ -17,7 +17,6 @@ export default makeStyles(
     },
     navigationIcons: {
       fontSize: '20px',
-      color: theme.palette.common.gray,
       cursor: 'pointer'
     },
     pathwayName: {

--- a/src/components/PathwaysList/PathwaysTable.tsx
+++ b/src/components/PathwaysList/PathwaysTable.tsx
@@ -25,7 +25,7 @@ import { useCurrentPathwayContext } from 'components/CurrentPathwayProvider';
 const PathwaysTable: FC = () => {
   const styles = useStyles();
   const { pathways, deletePathway } = usePathwaysContext();
-  const { setPathway } = useCurrentPathwayContext();
+  const { setCurrentPathway } = useCurrentPathwayContext();
   const [open, setOpen] = useState(false);
   const [editablePathway, setEditablePathway] = useState<Pathway>();
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
@@ -43,9 +43,9 @@ const PathwaysTable: FC = () => {
     (event: MouseEvent<HTMLButtonElement>): void => {
       setAnchorEl(event.currentTarget);
       const pathway = pathways.filter(pathway => pathway.id === event.currentTarget.id);
-      if (pathway.length) setPathway(pathway[0]);
+      if (pathway.length) setCurrentPathway(pathway[0]);
     },
-    [pathways, setPathway]
+    [pathways, setCurrentPathway]
   );
 
   const closeMenu = useCallback((): void => {

--- a/src/components/Sidebar/ActionNodeEditor.tsx
+++ b/src/components/Sidebar/ActionNodeEditor.tsx
@@ -36,7 +36,7 @@ interface ActionNodeEditorProps {
 }
 
 const ActionNodeEditor: FC<ActionNodeEditorProps> = ({ changeNodeType }) => {
-  const { pathwayRef, setPathway } = useCurrentPathwayContext();
+  const { pathwayRef, setCurrentPathway } = useCurrentPathwayContext();
   const { currentNode, currentNodeRef } = useCurrentNodeContext();
   const styles = useStyles();
 
@@ -55,10 +55,10 @@ const ActionNodeEditor: FC<ActionNodeEditorProps> = ({ changeNodeType }) => {
       convertBasicCQL(cql).then(elm => {
         // Disable lint for no-null assertion since it is already checked above
         // eslint-disable-next-line
-        setPathway(setActionNodeElm(pathwayRef.current!, currentNodeKey, elm));
+        setCurrentPathway(setActionNodeElm(pathwayRef.current!, currentNodeKey, elm));
       });
     },
-    [pathwayRef, setPathway]
+    [pathwayRef, setCurrentPathway]
   );
 
   const changeCode = useCallback(
@@ -68,9 +68,9 @@ const ActionNodeEditor: FC<ActionNodeEditorProps> = ({ changeNodeType }) => {
 
       const code = event?.target.value || '';
       const action = setActionCode(currentNode.action, code);
-      setPathway(setNodeAction(pathwayRef.current, currentNode.key, resetDisplay(action)));
+      setCurrentPathway(setNodeAction(pathwayRef.current, currentNode.key, resetDisplay(action)));
     },
-    [currentNodeRef, pathwayRef, setPathway]
+    [currentNodeRef, pathwayRef, setCurrentPathway]
   );
 
   const changeDescription = useCallback(
@@ -80,9 +80,9 @@ const ActionNodeEditor: FC<ActionNodeEditorProps> = ({ changeNodeType }) => {
 
       const description = event?.target.value || '';
       const action = setActionDescription(currentNode.action, description);
-      setPathway(setNodeAction(pathwayRef.current, currentNode.key, action));
+      setCurrentPathway(setNodeAction(pathwayRef.current, currentNode.key, action));
     },
-    [currentNodeRef, pathwayRef, setPathway]
+    [currentNodeRef, pathwayRef, setCurrentPathway]
   );
 
   const changeTitle = useCallback(
@@ -92,11 +92,11 @@ const ActionNodeEditor: FC<ActionNodeEditorProps> = ({ changeNodeType }) => {
 
       const title = event?.target.value || '';
       const action = setActionTitle(currentNode.action, title);
-      setPathway(setNodeAction(pathwayRef.current, currentNode.key, resetDisplay(action)));
+      setCurrentPathway(setNodeAction(pathwayRef.current, currentNode.key, resetDisplay(action)));
 
       addActionCQL(action, currentNode.key);
     },
-    [currentNodeRef, pathwayRef, setPathway, addActionCQL]
+    [currentNodeRef, pathwayRef, setCurrentPathway, addActionCQL]
   );
 
   const selectCodeSystem = useCallback(
@@ -106,9 +106,9 @@ const ActionNodeEditor: FC<ActionNodeEditorProps> = ({ changeNodeType }) => {
 
       const codeSystem = event?.target.value || '';
       const action = setActionCodeSystem(currentNode.action, codeSystem);
-      setPathway(setNodeAction(pathwayRef.current, currentNode.key, resetDisplay(action)));
+      setCurrentPathway(setNodeAction(pathwayRef.current, currentNode.key, resetDisplay(action)));
     },
-    [currentNodeRef, pathwayRef, setPathway]
+    [currentNodeRef, pathwayRef, setCurrentPathway]
   );
 
   const validateFunction = useCallback((): void => {
@@ -119,11 +119,11 @@ const ActionNodeEditor: FC<ActionNodeEditorProps> = ({ changeNodeType }) => {
     }
 
     const action = setActionResourceDisplay(currentNode.action, 'Example Text');
-    setPathway(setNodeAction(pathwayRef.current, currentNode.key, action));
+    setCurrentPathway(setNodeAction(pathwayRef.current, currentNode.key, action));
 
     // TODO: move addActionCQL to builder.ts
     addActionCQL(action, currentNode.key);
-  }, [currentNodeRef, pathwayRef, setPathway, addActionCQL]);
+  }, [currentNodeRef, pathwayRef, setCurrentPathway, addActionCQL]);
 
   const resetDisplay = (action: Action): Action => {
     return produce(action, (draftAction: Action) => {

--- a/src/components/Sidebar/ActionNodeEditor.tsx
+++ b/src/components/Sidebar/ActionNodeEditor.tsx
@@ -17,7 +17,6 @@ import { ActionNode, Action } from 'pathways-model';
 import useStyles from './styles';
 import { TextField } from '@material-ui/core';
 import { convertBasicCQL } from 'engine/cql-to-elm';
-import { usePathwaysContext } from 'components/PathwaysProvider';
 import { useCurrentPathwayContext } from 'components/CurrentPathwayProvider';
 import produce from 'immer';
 import { useCurrentNodeContext } from 'components/CurrentNodeProvider';
@@ -37,8 +36,7 @@ interface ActionNodeEditorProps {
 }
 
 const ActionNodeEditor: FC<ActionNodeEditorProps> = ({ changeNodeType }) => {
-  const { updatePathway } = usePathwaysContext();
-  const { pathwayRef } = useCurrentPathwayContext();
+  const { pathwayRef, setPathway } = useCurrentPathwayContext();
   const { currentNode, currentNodeRef } = useCurrentNodeContext();
   const styles = useStyles();
 
@@ -57,10 +55,10 @@ const ActionNodeEditor: FC<ActionNodeEditorProps> = ({ changeNodeType }) => {
       convertBasicCQL(cql).then(elm => {
         // Disable lint for no-null assertion since it is already checked above
         // eslint-disable-next-line
-        updatePathway(setActionNodeElm(pathwayRef.current!, currentNodeKey, elm));
+        setPathway(setActionNodeElm(pathwayRef.current!, currentNodeKey, elm));
       });
     },
-    [pathwayRef, updatePathway]
+    [pathwayRef, setPathway]
   );
 
   const changeCode = useCallback(
@@ -70,9 +68,9 @@ const ActionNodeEditor: FC<ActionNodeEditorProps> = ({ changeNodeType }) => {
 
       const code = event?.target.value || '';
       const action = setActionCode(currentNode.action, code);
-      updatePathway(setNodeAction(pathwayRef.current, currentNode.key, resetDisplay(action)));
+      setPathway(setNodeAction(pathwayRef.current, currentNode.key, resetDisplay(action)));
     },
-    [currentNodeRef, pathwayRef, updatePathway]
+    [currentNodeRef, pathwayRef, setPathway]
   );
 
   const changeDescription = useCallback(
@@ -82,9 +80,9 @@ const ActionNodeEditor: FC<ActionNodeEditorProps> = ({ changeNodeType }) => {
 
       const description = event?.target.value || '';
       const action = setActionDescription(currentNode.action, description);
-      updatePathway(setNodeAction(pathwayRef.current, currentNode.key, action));
+      setPathway(setNodeAction(pathwayRef.current, currentNode.key, action));
     },
-    [currentNodeRef, pathwayRef, updatePathway]
+    [currentNodeRef, pathwayRef, setPathway]
   );
 
   const changeTitle = useCallback(
@@ -94,11 +92,11 @@ const ActionNodeEditor: FC<ActionNodeEditorProps> = ({ changeNodeType }) => {
 
       const title = event?.target.value || '';
       const action = setActionTitle(currentNode.action, title);
-      updatePathway(setNodeAction(pathwayRef.current, currentNode.key, resetDisplay(action)));
+      setPathway(setNodeAction(pathwayRef.current, currentNode.key, resetDisplay(action)));
 
       addActionCQL(action, currentNode.key);
     },
-    [currentNodeRef, pathwayRef, updatePathway, addActionCQL]
+    [currentNodeRef, pathwayRef, setPathway, addActionCQL]
   );
 
   const selectCodeSystem = useCallback(
@@ -108,9 +106,9 @@ const ActionNodeEditor: FC<ActionNodeEditorProps> = ({ changeNodeType }) => {
 
       const codeSystem = event?.target.value || '';
       const action = setActionCodeSystem(currentNode.action, codeSystem);
-      updatePathway(setNodeAction(pathwayRef.current, currentNode.key, resetDisplay(action)));
+      setPathway(setNodeAction(pathwayRef.current, currentNode.key, resetDisplay(action)));
     },
-    [currentNodeRef, pathwayRef, updatePathway]
+    [currentNodeRef, pathwayRef, setPathway]
   );
 
   const validateFunction = useCallback((): void => {
@@ -121,11 +119,11 @@ const ActionNodeEditor: FC<ActionNodeEditorProps> = ({ changeNodeType }) => {
     }
 
     const action = setActionResourceDisplay(currentNode.action, 'Example Text');
-    updatePathway(setNodeAction(pathwayRef.current, currentNode.key, action));
+    setPathway(setNodeAction(pathwayRef.current, currentNode.key, action));
 
     // TODO: move addActionCQL to builder.ts
     addActionCQL(action, currentNode.key);
-  }, [currentNodeRef, pathwayRef, updatePathway, addActionCQL]);
+  }, [currentNodeRef, pathwayRef, setPathway, addActionCQL]);
 
   const resetDisplay = (action: Action): Action => {
     return produce(action, (draftAction: Action) => {

--- a/src/components/Sidebar/BranchTransition.tsx
+++ b/src/components/Sidebar/BranchTransition.tsx
@@ -36,7 +36,7 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition }) => {
     resetCurrentCriteria
   } = useCurrentCriteriaContext();
   const { resetCriteriaBuilder, setCriteriaBuilder } = useCriteriaBuilderContext();
-  const { pathwayRef, setPathway } = useCurrentPathwayContext();
+  const { pathwayRef, setCurrentPathway } = useCurrentPathwayContext();
   const { currentNodeRef } = useCurrentNodeContext();
   const criteriaOptions = useMemo(() => criteria.map(c => ({ value: c.id, label: c.label })), [
     criteria
@@ -67,14 +67,21 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition }) => {
   const handleUseCriteria = useCallback((): void => {
     if (hasCriteria && currentNodeRef.current && pathwayRef.current) {
       // delete the transition criteria
-      setPathway(
+      setCurrentPathway(
         removeTransitionCondition(pathwayRef.current, currentNodeRef.current.key, transition.id)
       );
       setUseCriteriaSelected(false);
     } else {
       setUseCriteriaSelected(!useCriteriaSelected);
     }
-  }, [useCriteriaSelected, currentNodeRef, pathwayRef, hasCriteria, transition.id, setPathway]);
+  }, [
+    useCriteriaSelected,
+    currentNodeRef,
+    pathwayRef,
+    hasCriteria,
+    transition.id,
+    setCurrentPathway
+  ]);
 
   const selectCriteriaSource = useCallback(
     (event: ChangeEvent<{ value: string }>): void => {
@@ -91,9 +98,9 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition }) => {
         selectedCriteria
       );
 
-      setPathway(newPathway);
+      setCurrentPathway(newPathway);
     },
-    [currentNodeRef, setPathway, pathwayRef, transitionRef, criteria]
+    [currentNodeRef, setCurrentPathway, pathwayRef, transitionRef, criteria]
   );
 
   const setCriteriaDisplay = useCallback(
@@ -101,7 +108,7 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition }) => {
       if (!currentNodeRef.current || !pathwayRef.current) return;
 
       const criteriaDisplay = event?.target.value || '';
-      setPathway(
+      setCurrentPathway(
         setTransitionConditionDescription(
           pathwayRef.current,
           currentNodeRef.current.key,
@@ -110,7 +117,7 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition }) => {
         )
       );
     },
-    [currentNodeRef, transition.id, setPathway, pathwayRef]
+    [currentNodeRef, transition.id, setCurrentPathway, pathwayRef]
   );
 
   const handleCriteriaName = useCallback(
@@ -175,11 +182,11 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition }) => {
       criteria[0]
     );
 
-    setPathway(newPathway);
+    setCurrentPathway(newPathway);
     handleBuildCriteriaCancel();
   }, [
     currentNodeRef,
-    setPathway,
+    setCurrentPathway,
     pathwayRef,
     transitionRef,
     currentCriteria,

--- a/src/components/Sidebar/BranchTransition.tsx
+++ b/src/components/Sidebar/BranchTransition.tsx
@@ -11,7 +11,6 @@ import {
 import { OutlinedDiv, SidebarButton } from '.';
 import { Transition } from 'pathways-model';
 import { useCriteriaContext } from 'components/CriteriaProvider';
-import { usePathwaysContext } from 'components/PathwaysProvider';
 import useStyles from './styles';
 import { useCurrentPathwayContext } from 'components/CurrentPathwayProvider';
 import { useCurrentNodeContext } from 'components/CurrentNodeProvider';
@@ -24,7 +23,6 @@ interface BranchTransitionProps {
 }
 
 const BranchTransition: FC<BranchTransitionProps> = ({ transition }) => {
-  const { updatePathway } = usePathwaysContext();
   const { criteria, addBuilderCriteria } = useCriteriaContext();
   const {
     buildCriteriaSelected,
@@ -38,7 +36,7 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition }) => {
     resetCurrentCriteria
   } = useCurrentCriteriaContext();
   const { resetCriteriaBuilder, setCriteriaBuilder } = useCriteriaBuilderContext();
-  const { pathwayRef } = useCurrentPathwayContext();
+  const { pathwayRef, setPathway } = useCurrentPathwayContext();
   const { currentNodeRef } = useCurrentNodeContext();
   const criteriaOptions = useMemo(() => criteria.map(c => ({ value: c.id, label: c.label })), [
     criteria
@@ -69,14 +67,14 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition }) => {
   const handleUseCriteria = useCallback((): void => {
     if (hasCriteria && currentNodeRef.current && pathwayRef.current) {
       // delete the transition criteria
-      updatePathway(
+      setPathway(
         removeTransitionCondition(pathwayRef.current, currentNodeRef.current.key, transition.id)
       );
       setUseCriteriaSelected(false);
     } else {
       setUseCriteriaSelected(!useCriteriaSelected);
     }
-  }, [useCriteriaSelected, currentNodeRef, pathwayRef, hasCriteria, transition.id, updatePathway]);
+  }, [useCriteriaSelected, currentNodeRef, pathwayRef, hasCriteria, transition.id, setPathway]);
 
   const selectCriteriaSource = useCallback(
     (event: ChangeEvent<{ value: string }>): void => {
@@ -93,9 +91,9 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition }) => {
         selectedCriteria
       );
 
-      updatePathway(newPathway);
+      setPathway(newPathway);
     },
-    [currentNodeRef, updatePathway, pathwayRef, transitionRef, criteria]
+    [currentNodeRef, setPathway, pathwayRef, transitionRef, criteria]
   );
 
   const setCriteriaDisplay = useCallback(
@@ -103,7 +101,7 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition }) => {
       if (!currentNodeRef.current || !pathwayRef.current) return;
 
       const criteriaDisplay = event?.target.value || '';
-      updatePathway(
+      setPathway(
         setTransitionConditionDescription(
           pathwayRef.current,
           currentNodeRef.current.key,
@@ -112,7 +110,7 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition }) => {
         )
       );
     },
-    [currentNodeRef, transition.id, updatePathway, pathwayRef]
+    [currentNodeRef, transition.id, setPathway, pathwayRef]
   );
 
   const handleCriteriaName = useCallback(
@@ -177,11 +175,11 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition }) => {
       criteria[0]
     );
 
-    updatePathway(newPathway);
+    setPathway(newPathway);
     handleBuildCriteriaCancel();
   }, [
     currentNodeRef,
-    updatePathway,
+    setPathway,
     pathwayRef,
     transitionRef,
     currentCriteria,

--- a/src/components/Sidebar/ConnectNodeButton.tsx
+++ b/src/components/Sidebar/ConnectNodeButton.tsx
@@ -3,7 +3,6 @@ import { SidebarButton } from 'components/Sidebar';
 import DropDown from 'components/elements/DropDown';
 import useStyles from './styles';
 import { addTransition } from 'utils/builder';
-import { usePathwaysContext } from 'components/PathwaysProvider';
 import { getConnectableNodes } from 'utils/nodeUtils';
 import { useCurrentPathwayContext } from 'components/CurrentPathwayProvider';
 import { useCurrentNodeContext } from 'components/CurrentNodeProvider';
@@ -12,9 +11,8 @@ import { faLevelDownAlt } from '@fortawesome/free-solid-svg-icons';
 import { Button } from '@material-ui/core';
 
 const ConnectNodeButton: FC = () => {
-  const { pathway, pathwayRef } = useCurrentPathwayContext();
+  const { pathway, pathwayRef, setPathway } = useCurrentPathwayContext();
   const { currentNode, currentNodeRef } = useCurrentNodeContext();
-  const { updatePathway } = usePathwaysContext();
 
   const styles = useStyles();
   const [open, setOpen] = useState(false);
@@ -27,10 +25,10 @@ const ConnectNodeButton: FC = () => {
     (event: ChangeEvent<{ value: string }>): void => {
       const nodeKey = event?.target.value;
       if (pathwayRef.current && currentNodeRef.current)
-        updatePathway(addTransition(pathwayRef.current, currentNodeRef.current.key, nodeKey));
+        setPathway(addTransition(pathwayRef.current, currentNodeRef.current.key, nodeKey));
       setOpen(false);
     },
-    [updatePathway, currentNodeRef, pathwayRef]
+    [setPathway, currentNodeRef, pathwayRef]
   );
 
   const showDropdown = useCallback(() => {

--- a/src/components/Sidebar/ConnectNodeButton.tsx
+++ b/src/components/Sidebar/ConnectNodeButton.tsx
@@ -11,7 +11,7 @@ import { faLevelDownAlt } from '@fortawesome/free-solid-svg-icons';
 import { Button } from '@material-ui/core';
 
 const ConnectNodeButton: FC = () => {
-  const { pathway, pathwayRef, setPathway } = useCurrentPathwayContext();
+  const { pathway, pathwayRef, setCurrentPathway } = useCurrentPathwayContext();
   const { currentNode, currentNodeRef } = useCurrentNodeContext();
 
   const styles = useStyles();
@@ -25,10 +25,10 @@ const ConnectNodeButton: FC = () => {
     (event: ChangeEvent<{ value: string }>): void => {
       const nodeKey = event?.target.value;
       if (pathwayRef.current && currentNodeRef.current)
-        setPathway(addTransition(pathwayRef.current, currentNodeRef.current.key, nodeKey));
+        setCurrentPathway(addTransition(pathwayRef.current, currentNodeRef.current.key, nodeKey));
       setOpen(false);
     },
-    [setPathway, currentNodeRef, pathwayRef]
+    [setCurrentPathway, currentNodeRef, pathwayRef]
   );
 
   const showDropdown = useCallback(() => {

--- a/src/components/Sidebar/DeleteSnackbar.tsx
+++ b/src/components/Sidebar/DeleteSnackbar.tsx
@@ -1,11 +1,18 @@
-import React, { FC, memo } from 'react';
+import React, { FC, memo, useCallback } from 'react';
 import { Snackbar, Button, IconButton } from '@material-ui/core';
 import { useSnackbarContext } from 'components/SnackbarProvider';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTimes } from '@fortawesome/free-solid-svg-icons';
+import { useCurrentPathwayContext } from 'components/CurrentPathwayProvider';
 
 const DeleteSnackbar: FC = () => {
+  const { undoPathway } = useCurrentPathwayContext();
   const { snackbarText, openSnackbar, handleCloseSnackbar } = useSnackbarContext();
+
+  const undo = useCallback(() => {
+    undoPathway();
+    handleCloseSnackbar();
+  }, [undoPathway, handleCloseSnackbar]);
 
   return (
     <Snackbar
@@ -19,7 +26,7 @@ const DeleteSnackbar: FC = () => {
       message={snackbarText}
       action={
         <React.Fragment>
-          <Button color="secondary" size="small" onClick={handleCloseSnackbar}>
+          <Button color="secondary" size="small" onClick={undo}>
             UNDO
           </Button>
           <IconButton size="small" aria-label="close" color="inherit" onClick={handleCloseSnackbar}>

--- a/src/components/Sidebar/ReferenceNodeEditor.tsx
+++ b/src/components/Sidebar/ReferenceNodeEditor.tsx
@@ -18,7 +18,7 @@ interface ReferenceNodeEditorProps {
 const ReferenceNodeEditor: FC<ReferenceNodeEditorProps> = ({ changeNodeType }) => {
   const { currentNode, currentNodeRef } = useCurrentNodeContext();
   const { pathways, updatePathway } = usePathwaysContext();
-  const { pathwayRef, setPathway } = useCurrentPathwayContext();
+  const { pathwayRef, setCurrentPathway } = useCurrentPathwayContext();
   const history = useHistory();
 
   const pathwayOptions = pathways.map((pathway: Pathway) => {
@@ -42,9 +42,9 @@ const ReferenceNodeEditor: FC<ReferenceNodeEditorProps> = ({ changeNodeType }) =
       return pathway.id === pathwayReferenceId;
     });
     if (referencedPathway) {
-      setPathway(referencedPathway);
+      setCurrentPathway(referencedPathway);
     }
-  }, [currentNode, pathways, setPathway]);
+  }, [currentNode, pathways, setCurrentPathway]);
 
   const selectPathwayReference = useCallback(
     (event: ChangeEvent<{ value: string }>): void => {

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -21,7 +21,7 @@ import DeleteSnackbar from './DeleteSnackbar';
 import ConnectNodeButton from 'components/Sidebar/ConnectNodeButton';
 
 const Sidebar: FC = () => {
-  const { pathway, pathwayRef, setPathway } = useCurrentPathwayContext();
+  const { pathway, pathwayRef, setCurrentPathway } = useCurrentPathwayContext();
   const { currentNode, currentNodeRef } = useCurrentNodeContext();
   const [isExpanded, setIsExpanded] = useState<boolean>(true);
   const styles = useStyles();
@@ -35,9 +35,9 @@ const Sidebar: FC = () => {
   const changeNodeType = useCallback(
     (nodeType: string): void => {
       if (currentNodeRef.current && pathwayRef.current)
-        setPathway(setNodeType(pathwayRef.current, currentNodeRef.current.key, nodeType));
+        setCurrentPathway(setNodeType(pathwayRef.current, currentNodeRef.current.key, nodeType));
     },
-    [pathwayRef, setPathway, currentNodeRef]
+    [pathwayRef, setCurrentPathway, currentNodeRef]
   );
 
   const selectNodeType = useCallback(
@@ -53,10 +53,10 @@ const Sidebar: FC = () => {
     const newNode = createNode();
     let newPathway = addNode(pathwayRef.current, newNode);
     newPathway = addTransition(newPathway, currentNodeRef.current.key, newNode.key);
-    setPathway(newPathway);
+    setCurrentPathway(newPathway);
     if (!isBranchNode(currentNodeRef.current))
       redirect(pathwayRef.current.id, newNode.key, history);
-  }, [pathwayRef, setPathway, currentNodeRef, history]);
+  }, [pathwayRef, setCurrentPathway, currentNodeRef, history]);
 
   if (!pathway) return <div>Error: No pathway</div>;
   if (!currentNode) return <div>Error: No current node</div>;

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,7 +1,7 @@
 import React, { FC, memo, useCallback, useState, useRef, ChangeEvent } from 'react';
 import { useHistory } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faChevronLeft, faChevronRight, faPlus, faRedo, faUndo } from '@fortawesome/free-solid-svg-icons';
+import { faChevronLeft, faChevronRight, faPlus } from '@fortawesome/free-solid-svg-icons';
 import {
   SidebarHeader,
   ActionNodeEditor,
@@ -23,7 +23,7 @@ import ConnectNodeButton from 'components/Sidebar/ConnectNodeButton';
 
 const Sidebar: FC = () => {
   const { updatePathway } = usePathwaysContext();
-  const { pathway, pathwayRef, canUndoPathway, canRedoPathway, undoPathway, redoPathway } = useCurrentPathwayContext();
+  const { pathway, pathwayRef } = useCurrentPathwayContext();
   const { currentNode, currentNodeRef } = useCurrentNodeContext();
   const [isExpanded, setIsExpanded] = useState<boolean>(true);
   const styles = useStyles();
@@ -148,21 +148,6 @@ const Sidebar: FC = () => {
                 <ConnectNodeButton />
               </>
             )}
-
-            <SidebarButton
-              buttonName="Undo"
-              buttonIcon={faUndo}
-              buttonText="Undo last change to the pathway"
-              onClick={undoPathway}
-              disabled={!canUndoPathway}
-            />
-            <SidebarButton
-              buttonName="Redo"
-              buttonIcon={faRedo}
-              buttonText="Redo last change to the pathway"
-              onClick={redoPathway}
-              disabled={!canRedoPathway}
-            />
           </div>
         )}
         <div className={styles.toggleSidebar} onClick={toggleSidebar}>

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -10,7 +10,7 @@ import {
   BranchTransition,
   ReferenceNodeEditor
 } from 'components/Sidebar';
-import { setNodeType, addTransition, createNode, addNode } from 'utils/builder';
+import { setNodeType, addTransition, createNode, addNode, getNodeType } from 'utils/builder';
 import { usePathwaysContext } from 'components/PathwaysProvider';
 import useStyles from './styles';
 import { useCurrentPathwayContext } from 'components/CurrentPathwayProvider';
@@ -22,8 +22,7 @@ import DeleteSnackbar from './DeleteSnackbar';
 import ConnectNodeButton from 'components/Sidebar/ConnectNodeButton';
 
 const Sidebar: FC = () => {
-  const { updatePathway } = usePathwaysContext();
-  const { pathway, pathwayRef } = useCurrentPathwayContext();
+  const { pathway, pathwayRef, setPathway } = useCurrentPathwayContext();
   const { currentNode, currentNodeRef } = useCurrentNodeContext();
   const [isExpanded, setIsExpanded] = useState<boolean>(true);
   const styles = useStyles();
@@ -37,9 +36,9 @@ const Sidebar: FC = () => {
   const changeNodeType = useCallback(
     (nodeType: string): void => {
       if (currentNodeRef.current && pathwayRef.current)
-        updatePathway(setNodeType(pathwayRef.current, currentNodeRef.current.key, nodeType));
+        setPathway(setNodeType(pathwayRef.current, currentNodeRef.current.key, nodeType));
     },
-    [pathwayRef, updatePathway, currentNodeRef]
+    [pathwayRef, setPathway, currentNodeRef]
   );
 
   const selectNodeType = useCallback(
@@ -55,10 +54,10 @@ const Sidebar: FC = () => {
     const newNode = createNode();
     let newPathway = addNode(pathwayRef.current, newNode);
     newPathway = addTransition(newPathway, currentNodeRef.current.key, newNode.key);
-    updatePathway(newPathway);
+    setPathway(newPathway);
     if (!isBranchNode(currentNodeRef.current))
       redirect(pathwayRef.current.id, newNode.key, history);
-  }, [pathwayRef, updatePathway, currentNodeRef, history]);
+  }, [pathwayRef, setPathway, currentNodeRef, history]);
 
   if (!pathway) return <div>Error: No pathway</div>;
   if (!currentNode) return <div>Error: No current node</div>;

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -10,8 +10,7 @@ import {
   BranchTransition,
   ReferenceNodeEditor
 } from 'components/Sidebar';
-import { setNodeType, addTransition, createNode, addNode, getNodeType } from 'utils/builder';
-import { usePathwaysContext } from 'components/PathwaysProvider';
+import { setNodeType, addTransition, createNode, addNode } from 'utils/builder';
 import useStyles from './styles';
 import { useCurrentPathwayContext } from 'components/CurrentPathwayProvider';
 import { useCurrentNodeContext } from 'components/CurrentNodeProvider';

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,7 +1,7 @@
 import React, { FC, memo, useCallback, useState, useRef, ChangeEvent } from 'react';
 import { useHistory } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faChevronLeft, faChevronRight, faPlus } from '@fortawesome/free-solid-svg-icons';
+import { faChevronLeft, faChevronRight, faPlus, faRedo, faUndo } from '@fortawesome/free-solid-svg-icons';
 import {
   SidebarHeader,
   ActionNodeEditor,
@@ -23,7 +23,7 @@ import ConnectNodeButton from 'components/Sidebar/ConnectNodeButton';
 
 const Sidebar: FC = () => {
   const { updatePathway } = usePathwaysContext();
-  const { pathway, pathwayRef } = useCurrentPathwayContext();
+  const { pathway, pathwayRef, canUndoPathway, canRedoPathway, undoPathway, redoPathway } = useCurrentPathwayContext();
   const { currentNode, currentNodeRef } = useCurrentNodeContext();
   const [isExpanded, setIsExpanded] = useState<boolean>(true);
   const styles = useStyles();
@@ -148,6 +148,21 @@ const Sidebar: FC = () => {
                 <ConnectNodeButton />
               </>
             )}
+
+            <SidebarButton
+              buttonName="Undo"
+              buttonIcon={faUndo}
+              buttonText="Undo last change to the pathway"
+              onClick={undoPathway}
+              disabled={!canUndoPathway}
+            />
+            <SidebarButton
+              buttonName="Redo"
+              buttonIcon={faRedo}
+              buttonText="Redo last change to the pathway"
+              onClick={redoPathway}
+              disabled={!canRedoPathway}
+            />
           </div>
         )}
         <div className={styles.toggleSidebar} onClick={toggleSidebar}>

--- a/src/components/Sidebar/SidebarHeader.tsx
+++ b/src/components/Sidebar/SidebarHeader.tsx
@@ -30,7 +30,7 @@ const SidebarHeader: FC<SidebarHeaderProps> = ({ node, isTransition = false }) =
   const [openDelete, setOpenDelete] = useState<boolean>(false);
   const { currentNodeRef } = useCurrentNodeContext();
   const { setSnackbarText, setOpenSnackbar } = useSnackbarContext();
-  const { pathway, pathwayRef, setPathway } = useCurrentPathwayContext();
+  const { pathway, pathwayRef, setCurrentPathway } = useCurrentPathwayContext();
   const inputRef = useRef<HTMLInputElement>(null);
   const nodeLabel = node?.label || '';
   const styles = useStyles();
@@ -49,9 +49,9 @@ const SidebarHeader: FC<SidebarHeaderProps> = ({ node, isTransition = false }) =
 
   const changeNodeLabel = useCallback(() => {
     const label = inputRef.current?.value ?? '';
-    if (pathwayRef.current) setPathway(setNodeLabel(pathwayRef.current, node.key, label));
+    if (pathwayRef.current) setCurrentPathway(setNodeLabel(pathwayRef.current, node.key, label));
     setShowInput(false);
-  }, [pathwayRef, setPathway, node.key]);
+  }, [pathwayRef, setCurrentPathway, node.key]);
 
   const handleShowInput = useCallback(() => {
     setShowInput(true);
@@ -60,7 +60,7 @@ const SidebarHeader: FC<SidebarHeaderProps> = ({ node, isTransition = false }) =
   const deleteNode = useCallback(() => {
     if (pathwayRef.current && canDeleteNode(pathwayRef.current, node.transitions)) {
       const parents = findParents(pathwayRef.current.nodes, node.key);
-      setPathway(removeNode(pathwayRef.current, node.key));
+      setCurrentPathway(removeNode(pathwayRef.current, node.key));
       redirect(pathwayRef.current.id, parents[0], history);
       setOpenDelete(false);
       setSnackbarText(`${node.label} node deleted successfully`);
@@ -68,7 +68,7 @@ const SidebarHeader: FC<SidebarHeaderProps> = ({ node, isTransition = false }) =
     }
   }, [
     pathwayRef,
-    setPathway,
+    setCurrentPathway,
     setSnackbarText,
     setOpenSnackbar,
     node.key,
@@ -83,14 +83,14 @@ const SidebarHeader: FC<SidebarHeaderProps> = ({ node, isTransition = false }) =
       pathwayRef.current &&
       !willOrphanChild(pathwayRef.current, node.key)
     ) {
-      setPathway(removeTransition(pathwayRef.current, currentNodeRef.current.key, node.key));
+      setCurrentPathway(removeTransition(pathwayRef.current, currentNodeRef.current.key, node.key));
       setOpenDelete(false);
       setSnackbarText(
         `Transition from ${currentNodeRef.current.label} to ${node.label} deleted successfully`
       );
       setOpenSnackbar(true);
     }
-  }, [pathwayRef, currentNodeRef, setPathway, setSnackbarText, setOpenSnackbar, node]);
+  }, [pathwayRef, currentNodeRef, setCurrentPathway, setSnackbarText, setOpenSnackbar, node]);
 
   const openDeleteModal = useCallback((): void => {
     setOpenDelete(true);
@@ -154,7 +154,7 @@ const SidebarHeader: FC<SidebarHeaderProps> = ({ node, isTransition = false }) =
               className={clsx(
                 styles.headerLabel,
                 styles.headerLabelText,
-                node.key === 'Start' && styles.headerLabelStart
+                node.type === 'start' && styles.headerLabelStart
               )}
             >
               {nodeLabel}

--- a/src/components/Sidebar/SidebarHeader.tsx
+++ b/src/components/Sidebar/SidebarHeader.tsx
@@ -11,7 +11,6 @@ import { IconButton, FormControl, Input, Tooltip } from '@material-ui/core';
 
 import { PathwayNode } from 'pathways-model';
 import { setNodeLabel, removeNode, removeTransition } from 'utils/builder';
-import { usePathwaysContext } from 'components/PathwaysProvider';
 import useStyles from './styles';
 import { useCurrentPathwayContext } from 'components/CurrentPathwayProvider';
 import { useHistory } from 'react-router-dom';
@@ -26,13 +25,12 @@ interface SidebarHeaderProps {
 }
 
 const SidebarHeader: FC<SidebarHeaderProps> = ({ node, isTransition = false }) => {
-  const { updatePathway } = usePathwaysContext();
   const [showInput, setShowInput] = useState<boolean>(false);
   const [openTooltip, setOpenTooltip] = useState<boolean>(false);
   const [openDelete, setOpenDelete] = useState<boolean>(false);
   const { currentNodeRef } = useCurrentNodeContext();
   const { setSnackbarText, setOpenSnackbar } = useSnackbarContext();
-  const { pathway, pathwayRef } = useCurrentPathwayContext();
+  const { pathway, pathwayRef, setPathway } = useCurrentPathwayContext();
   const inputRef = useRef<HTMLInputElement>(null);
   const nodeLabel = node?.label || '';
   const styles = useStyles();
@@ -51,9 +49,9 @@ const SidebarHeader: FC<SidebarHeaderProps> = ({ node, isTransition = false }) =
 
   const changeNodeLabel = useCallback(() => {
     const label = inputRef.current?.value ?? '';
-    if (pathwayRef.current) updatePathway(setNodeLabel(pathwayRef.current, node.key, label));
+    if (pathwayRef.current) setPathway(setNodeLabel(pathwayRef.current, node.key, label));
     setShowInput(false);
-  }, [pathwayRef, updatePathway, node.key]);
+  }, [pathwayRef, setPathway, node.key]);
 
   const handleShowInput = useCallback(() => {
     setShowInput(true);
@@ -62,7 +60,7 @@ const SidebarHeader: FC<SidebarHeaderProps> = ({ node, isTransition = false }) =
   const deleteNode = useCallback(() => {
     if (pathwayRef.current && canDeleteNode(pathwayRef.current, node.transitions)) {
       const parents = findParents(pathwayRef.current.nodes, node.key);
-      updatePathway(removeNode(pathwayRef.current, node.key));
+      setPathway(removeNode(pathwayRef.current, node.key));
       redirect(pathwayRef.current.id, parents[0], history);
       setOpenDelete(false);
       setSnackbarText(`${node.label} node deleted successfully`);
@@ -70,7 +68,7 @@ const SidebarHeader: FC<SidebarHeaderProps> = ({ node, isTransition = false }) =
     }
   }, [
     pathwayRef,
-    updatePathway,
+    setPathway,
     setSnackbarText,
     setOpenSnackbar,
     node.key,
@@ -85,14 +83,14 @@ const SidebarHeader: FC<SidebarHeaderProps> = ({ node, isTransition = false }) =
       pathwayRef.current &&
       !willOrphanChild(pathwayRef.current, node.key)
     ) {
-      updatePathway(removeTransition(pathwayRef.current, currentNodeRef.current.key, node.key));
+      setPathway(removeTransition(pathwayRef.current, currentNodeRef.current.key, node.key));
       setOpenDelete(false);
       setSnackbarText(
         `Transition from ${currentNodeRef.current.label} to ${node.label} deleted successfully`
       );
       setOpenSnackbar(true);
     }
-  }, [pathwayRef, currentNodeRef, updatePathway, setSnackbarText, setOpenSnackbar, node]);
+  }, [pathwayRef, currentNodeRef, setPathway, setSnackbarText, setOpenSnackbar, node]);
 
   const openDeleteModal = useCallback((): void => {
     setOpenDelete(true);

--- a/src/components/Sidebar/SidebarHeader.tsx
+++ b/src/components/Sidebar/SidebarHeader.tsx
@@ -156,11 +156,11 @@ const SidebarHeader: FC<SidebarHeaderProps> = ({ node, isTransition = false }) =
               className={clsx(
                 styles.headerLabel,
                 styles.headerLabelText,
-                node.type === 'start' && styles.headerLabelStart
+                node.key === 'Start' && styles.headerLabelStart
               )}
             >
               {nodeLabel}
-              {node.type !== 'start' && (
+              {node.key !== 'Start' && (
                 <FontAwesomeIcon className={styles.editIcon} icon={faEdit} />
               )}
             </div>

--- a/src/index.js
+++ b/src/index.js
@@ -10,11 +10,11 @@ import './styles/index.scss';
 
 // Enable why did you render for development mode
 // Will automatically track all memoized components
-// if (process.env.NODE_ENV === 'development') {
-//   const whyDidYouRender = require('@welldone-software/why-did-you-render');
-//   whyDidYouRender(React, {
-//     trackAllPureComponents: true
-//   });
-// }
+if (process.env.NODE_ENV === 'development') {
+  const whyDidYouRender = require('@welldone-software/why-did-you-render');
+  whyDidYouRender(React, {
+    trackAllPureComponents: true
+  });
+}
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/src/index.js
+++ b/src/index.js
@@ -10,11 +10,11 @@ import './styles/index.scss';
 
 // Enable why did you render for development mode
 // Will automatically track all memoized components
-if (process.env.NODE_ENV === 'development') {
-  const whyDidYouRender = require('@welldone-software/why-did-you-render');
-  whyDidYouRender(React, {
-    trackAllPureComponents: true
-  });
-}
+// if (process.env.NODE_ENV === 'development') {
+//   const whyDidYouRender = require('@welldone-software/why-did-you-render');
+//   whyDidYouRender(React, {
+//     trackAllPureComponents: true
+//   });
+// }
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/src/styles/theme.tsx
+++ b/src/styles/theme.tsx
@@ -198,8 +198,9 @@ const materialUiOverridesBase = {
   },
   MuiIconButton: {
     root: {
+      color: colors.gray,
       '&:disabled': {
-        color: colors.grayLight
+        color: colors.grayMedium
       }
     }
   }
@@ -262,6 +263,14 @@ const materialUiOverridesDark = {
   MuiMenuItem: {
     root: {
       color: colors.grayDark
+    }
+  },
+  MuiIconButton: {
+    root: {
+      color: colors.white,
+      '&:disabled': {
+        color: colors.grayLight
+      }
     }
   }
 };

--- a/src/utils/useRefUndoState.ts
+++ b/src/utils/useRefUndoState.ts
@@ -1,0 +1,24 @@
+import { useEffect, useRef, useState, MutableRefObject, useCallback } from 'react';
+import useUndo from 'use-undo';
+
+function useRefUndoState<T>(initialValue: T): [T, MutableRefObject<T>, boolean, boolean, Function, Function, Function] {
+    const [
+        state,
+        {
+            set: setState,
+            undo: undoState,
+            redo: redoState,
+            canUndo,
+            canRedo
+        }
+    ] = useUndo<T>(initialValue);
+    const stateRef = useRef(state.present);
+
+    useEffect(() => {
+        stateRef.current = state.present;
+    }, [state]);
+
+    return [state.present, stateRef, canUndo, canRedo, undoState, redoState, setState];
+}
+
+export default useRefUndoState;

--- a/src/utils/useRefUndoState.ts
+++ b/src/utils/useRefUndoState.ts
@@ -1,24 +1,20 @@
-import { useEffect, useRef, useState, MutableRefObject, useCallback } from 'react';
+import { useEffect, useRef, MutableRefObject } from 'react';
 import useUndo from 'use-undo';
 
-function useRefUndoState<T>(initialValue: T): [T, MutableRefObject<T>, boolean, boolean, Function, Function, Function] {
-    const [
-        state,
-        {
-            set: setState,
-            undo: undoState,
-            redo: redoState,
-            canUndo,
-            canRedo
-        }
-    ] = useUndo<T>(initialValue);
-    const stateRef = useRef(state.present);
+function useRefUndoState<T>(
+  initialValue: T
+): [T, MutableRefObject<T>, boolean, boolean, Function, Function, Function, Function] {
+  const [
+    state,
+    { set: setState, reset: resetState, undo: undoState, redo: redoState, canUndo, canRedo }
+  ] = useUndo<T>(initialValue);
+  const stateRef = useRef(state.present);
 
-    useEffect(() => {
-        stateRef.current = state.present;
-    }, [state]);
+  useEffect(() => {
+    stateRef.current = state.present;
+  }, [state]);
 
-    return [state.present, stateRef, canUndo, canRedo, undoState, redoState, setState];
+  return [state.present, stateRef, canUndo, canRedo, undoState, redoState, resetState, setState];
 }
 
 export default useRefUndoState;

--- a/yarn.lock
+++ b/yarn.lock
@@ -11333,6 +11333,11 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
+use-undo@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/use-undo/-/use-undo-1.0.3.tgz#d1aaedb4492ff637e67f0f79ec10122cd6d9c3fe"
+  integrity sha512-ZrGVugCqXX3PHPv0vQPbFitPenRqja7xYS7gvDEj+O4TkPl/6kaaTxZSseslPQrjMEhfZMcQMuFKqDuMMEAYNA==
+
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5478,6 +5478,11 @@ hosted-git-info@^2.1.4:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.8.tgz#7539bd4bc1e0e0a895815a2e0262420b12858488"
   integrity sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==
 
+hotkeys-js@^3.8.1:
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/hotkeys-js/-/hotkeys-js-3.8.1.tgz#fa7051f73bf1dc92a8b8d580a40b247f91966376"
+  integrity sha512-YlhVQtyG9f1b7GhtzdhR0Pl+cImD1ZrKI6zYUa7QLd0zuThiL7RzZ+ANJyy7z+kmcCpNYBf5PjBa3CjiQ5PFpw==
+
 hpack.js@^2.1.6:
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/hpack.js/-/hpack.js-2.1.6.tgz#87774c0949e513f42e84575b3c45681fade2a0b2"
@@ -9322,6 +9327,15 @@ react-fontawesome@^1.6.1:
   integrity sha512-kottReWW1I9Uupub6A5YX4VK7qfpFnEjAcm5zB4Aepst7iofONT27GJYdTcRsj7q5uQu9PXBL7GsxAFKANNUVg==
   dependencies:
     prop-types "^15.5.6"
+
+react-hot-keys@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/react-hot-keys/-/react-hot-keys-2.6.0.tgz#9c360d45d4d45a0cde35c59eb05335230f8e9f37"
+  integrity sha512-q7UKLGxZyWhIeyNp4TIp5ardcIF5lPeS8Lmh5gTKH+4IOQDrfMkyvAoz1XFYKR2UDc4GW9sEDrzVrqVZu/HrAw==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+    hotkeys-js "^3.8.1"
+    prop-types "^15.7.2"
 
 react-input-autosize@^2.2.2:
   version "2.2.2"


### PR DESCRIPTION
Implement undo and redo for pathway changes.

Modified the app to use the CurrentPathwayProvider for changes. This provider then synchronizes with the PathwayProvider (list of all pathways). All of the functionality has remained the same with the one exception that if the nodeid in the url does not exist the url does not update to 'Start'. The start node is still active but the url shows the nodeid which does not exist.