### PR TITLE
Fix "read only property `criteriaSource`" Error

### DIFF
--- a/src/components/PathwaysProvider.tsx
+++ b/src/components/PathwaysProvider.tsx
@@ -115,10 +115,10 @@ export const PathwaysProvider: FC<PathwaysProviderProps> = memo(function Pathway
             const criteriaSource = criteria.find(
               crit => crit.elm?.library.identifier.id === library && crit.statement === statement
             )?.id;
+            // Only update if a criteria source is actually found.
             if (criteriaSource) {
               setPathways((currentPathways: Pathway[]) => {
                 return produce(currentPathways, draftPathways => {
-                  console.log('producing')
                   const draftCondition =
                     draftPathways[pathwayIndex].nodes[nodeIndex].transitions[transitionIndex]
                       .condition;

--- a/src/components/PathwaysProvider.tsx
+++ b/src/components/PathwaysProvider.tsx
@@ -13,6 +13,7 @@ import config from 'utils/ConfigManager';
 import useGetService from './Services';
 import useRefState from 'utils/useRefState';
 import { useCriteriaContext } from './CriteriaProvider';
+import produce from 'immer';
 
 interface PathwaysContextInterface {
   pathways: Pathway[];
@@ -105,20 +106,31 @@ export const PathwaysProvider: FC<PathwaysProviderProps> = memo(function Pathway
   // Update criteriaSource if criteria change
   useEffect(() => {
     const criteriaIds = criteria.map(crit => crit.id);
-    pathways.forEach(pathway =>
-      Object.values(pathway.nodes).forEach(node => {
-        node.transitions.forEach(({ condition }) => {
+    pathways.forEach((pathway, pathwayIndex) =>
+      Object.entries(pathway.nodes).forEach(([nodeIndex, node]) => {
+        node.transitions.forEach(({ condition }, transitionIndex) => {
           // If a matching criteria does not already exist, try and find one
           if (condition && !criteriaIds.includes(condition.criteriaSource as string)) {
             const [library, statement] = condition.cql.split('.');
-            condition.criteriaSource = criteria.find(
+            const criteriaSource = criteria.find(
               crit => crit.elm?.library.identifier.id === library && crit.statement === statement
             )?.id;
+            if (criteriaSource) {
+              setPathways((currentPathways: Pathway[]) => {
+                return produce(currentPathways, draftPathways => {
+                  console.log('producing')
+                  const draftCondition =
+                    draftPathways[pathwayIndex].nodes[nodeIndex].transitions[transitionIndex]
+                      .condition;
+                  if (draftCondition) draftCondition.criteriaSource = criteriaSource;
+                });
+              });
+            }
           }
         });
       })
     );
-  }, [criteria, pathways]);
+  }, [criteria, pathways, setPathways]);
 
   switch (service.status) {
     case 'error':


### PR DESCRIPTION
My last PR broke a React cardinal rule...[Do Not Modify State Directly!](https://reactjs.org/docs/state-and-lifecycle.html#do-not-modify-state-directly). This PR attempts to right those wrongs.

Previously if one tried to update a criteria description without having a criteria selected this error would be seen: `TypeError: Cannot assign to read only property 'criteriaSource' of object '#<Object>'`