### PR TITLE
Transition label updates

### DIFF
--- a/src/components/DagreGraph/GraphEdges.styles.ts
+++ b/src/components/DagreGraph/GraphEdges.styles.ts
@@ -16,7 +16,7 @@ export default makeStyles(
       height: '100%',
       zIndex: 1,
       '& text': {
-        fontSize: '18px'
+        fontSize: '14px'
       },
       '& #arrowhead-inactive polygon': {
         fill: theme.palette.common.blue

--- a/src/components/DagreGraph/GraphEdges.tsx
+++ b/src/components/DagreGraph/GraphEdges.tsx
@@ -65,7 +65,7 @@ const Edge: FC<EdgeProps> = ({ label, points, isActive }) => {
         truncated = true;
         return `${trimmedLine.substring(0, TRUNCATION_SIZE - 1)}...`;
       }
-      return line;
+      return trimmedLine;
     });
 
     return { lines: labelTextLines, isTruncated: truncated };

--- a/src/components/Sidebar/BranchTransition.tsx
+++ b/src/components/Sidebar/BranchTransition.tsx
@@ -228,6 +228,7 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition }) => {
               variant="outlined"
               onChange={setCriteriaDisplay}
               error={!criteriaDisplayIsValid}
+              helperText='Use commas "," to separate into multiple lines (up to 3)'
             />
           </>
 


### PR DESCRIPTION
This PR satisfies [PATHWAYS-385](https://jira.mitre.org/browse/PATHWAYS-385) and does the following:

- Reduces the font size of the transition labels
- Increases the truncation size cutoff for transition labels from 12 characters to 20 characters
- Adds the ability to split transition labels into up to 3 lines using a comma `,` (adds helper text to input to indicate)

Before:
<img width="298" alt="Screen Shot 2020-10-16 at 2 09 24 PM" src="https://user-images.githubusercontent.com/5418735/96293773-47a08280-0fb9-11eb-84f6-72c832f26eff.png">

After:
<img width="306" alt="Screen Shot 2020-10-16 at 2 08 49 PM" src="https://user-images.githubusercontent.com/5418735/96293793-4e2efa00-0fb9-11eb-9b1e-15647cbbb9b6.png">

To test: Import the attached pathway. Try editing any of the transition labels.

Note: This is branched off of [PR-57](https://github.com/mcode/pathway-builder/pull/57) which fixes a bug that was needed to build up a pathway used for testing. Therefore, this should be merged after that PR.

Note: There exists an issue with transition label placement (overlapping, crowding) when pathways become large. You will see this in the example pathway. I will add a separate JIRA task to deal with this issue as it was out of scope.


[NCCN Invasive Breast Cancer v5.2020 - BINV-15.json.zip](https://github.com/mcode/pathway-builder/files/5393517/NCCN.Invasive.Breast.Cancer.v5.2020.-.BINV-15.json.zip)



