### PR TITLE
add autocomplete

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.11.2",
     "@fortawesome/react-fontawesome": "^0.1.7",
     "@material-ui/core": "^4.9.5",
+    "@material-ui/lab": "^4.0.0-alpha.56",
     "@types/dagre": "^0.7.42",
     "@types/fhir": "^0.0.31",
     "@types/jest": "^24.0.25",

--- a/src/components/CriteriaBuilder/CriteriaBuilder.tsx
+++ b/src/components/CriteriaBuilder/CriteriaBuilder.tsx
@@ -48,27 +48,6 @@ const CriteriaBuilder: FC = () => {
     }
   ];
 
-  const onElementSelected = useCallback(
-    (event: ChangeEvent<{ value: string }>): void => {
-      setSelectedElement(event?.target.value || '');
-    },
-    [setSelectedElement]
-  );
-
-  const onDemoElementSelected = useCallback(
-    (event: ChangeEvent<{ value: string }>): void => {
-      setSelectedDemoElement(event?.target.value || '');
-    },
-    [setSelectedDemoElement]
-  );
-
-  const onGenderSelected = useCallback(
-    (event: ChangeEvent<{ value: string }>): void => {
-      setGender(event?.target.value || '');
-    },
-    [setGender]
-  );
-
   const onMinimumAgeChange = useCallback(
     (event: ChangeEvent<{ value: string }>): void => {
       setMinimumAge(parseInt(event?.target.value) || 0);
@@ -136,7 +115,7 @@ const CriteriaBuilder: FC = () => {
               id="Choose Element Type"
               label="Choose Element Type"
               options={elementOptions}
-              onChange={onElementSelected}
+              onChange={setSelectedElement}
               value={selectedElement}
             />
             {selectedElement && (
@@ -144,7 +123,7 @@ const CriteriaBuilder: FC = () => {
                 id={`Select ${selectedElement} element`}
                 label={`Select ${selectedElement} element`}
                 options={demoElementOptions}
-                onChange={onDemoElementSelected}
+                onChange={setSelectedDemoElement}
                 value={selectedDemoElement}
               />
             )}
@@ -165,7 +144,7 @@ const CriteriaBuilder: FC = () => {
                   id="Select Gender"
                   label="Gender"
                   options={genderOptions}
-                  onChange={onGenderSelected}
+                  onChange={setGender}
                   value={gender}
                 />
               </>

--- a/src/components/Sidebar/ActionNodeEditor.tsx
+++ b/src/components/Sidebar/ActionNodeEditor.tsx
@@ -40,13 +40,6 @@ const ActionNodeEditor: FC<ActionNodeEditorProps> = ({ changeNodeType }) => {
   const { currentNode, currentNodeRef } = useCurrentNodeContext();
   const styles = useStyles();
 
-  const selectNodeType = useCallback(
-    (event: ChangeEvent<{ value: string }>): void => {
-      changeNodeType(event?.target.value || '');
-    },
-    [changeNodeType]
-  );
-
   const addActionCQL = useCallback(
     (action: Action, currentNodeKey: string): void => {
       if (!pathwayRef.current) return;
@@ -100,11 +93,9 @@ const ActionNodeEditor: FC<ActionNodeEditorProps> = ({ changeNodeType }) => {
   );
 
   const selectCodeSystem = useCallback(
-    (event: ChangeEvent<{ value: string }>): void => {
+    (codeSystem: string): void => {
       const currentNode = currentNodeRef.current as ActionNode;
       if (!currentNode.action || !pathwayRef.current) return;
-
-      const codeSystem = event?.target.value || '';
       const action = setActionCodeSystem(currentNode.action, codeSystem);
       setCurrentPathway(setNodeAction(pathwayRef.current, currentNode.key, resetDisplay(action)));
     },
@@ -174,7 +165,7 @@ const ActionNodeEditor: FC<ActionNodeEditorProps> = ({ changeNodeType }) => {
             id="nodeType"
             label="Node Type"
             options={nodeTypeOptions}
-            onChange={selectNodeType}
+            onChange={changeNodeType}
             value={resource.resourceType}
           />
 

--- a/src/components/Sidebar/BranchTransition.tsx
+++ b/src/components/Sidebar/BranchTransition.tsx
@@ -223,7 +223,7 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition }) => {
 
             <TextField
               label="Criteria Display"
-              style={{ width: '100%' }}
+              className={styles.criteriaText}
               value={transition.condition?.description || ''}
               variant="outlined"
               onChange={setCriteriaDisplay}

--- a/src/components/Sidebar/BranchTransition.tsx
+++ b/src/components/Sidebar/BranchTransition.tsx
@@ -84,10 +84,9 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition }) => {
   ]);
 
   const selectCriteriaSource = useCallback(
-    (event: ChangeEvent<{ value: string }>): void => {
+    (criteriaId: string): void => {
       if (!currentNodeRef.current || !pathwayRef.current) return;
 
-      const criteriaId = event?.target.value || '';
       const selectedCriteria = criteria.find(c => c.id === criteriaId);
       if (!selectedCriteria) return;
       const newPathway = setTransitionCondition(
@@ -224,6 +223,7 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition }) => {
 
             <TextField
               label="Criteria Display"
+              style={{ width: '100%' }}
               value={transition.condition?.description || ''}
               variant="outlined"
               onChange={setCriteriaDisplay}

--- a/src/components/Sidebar/ConnectNodeButton.tsx
+++ b/src/components/Sidebar/ConnectNodeButton.tsx
@@ -1,4 +1,4 @@
-import React, { useState, memo, useCallback, ChangeEvent, FC } from 'react';
+import React, { useState, memo, useCallback, FC } from 'react';
 import { SidebarButton } from 'components/Sidebar';
 import DropDown from 'components/elements/DropDown';
 import useStyles from './styles';
@@ -22,8 +22,7 @@ const ConnectNodeButton: FC = () => {
   const optionsAvailable = options.length > 0;
 
   const connectToNode = useCallback(
-    (event: ChangeEvent<{ value: string }>): void => {
-      const nodeKey = event?.target.value;
+    (nodeKey: string): void => {
       if (pathwayRef.current && currentNodeRef.current)
         setCurrentPathway(addTransition(pathwayRef.current, currentNodeRef.current.key, nodeKey));
       setOpen(false);

--- a/src/components/Sidebar/ReferenceNodeEditor.tsx
+++ b/src/components/Sidebar/ReferenceNodeEditor.tsx
@@ -1,4 +1,4 @@
-import React, { FC, memo, useCallback, ChangeEvent } from 'react';
+import React, { FC, memo, useCallback } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import DropDown from 'components/elements/DropDown';
 import useStyles from './styles';
@@ -29,13 +29,6 @@ const ReferenceNodeEditor: FC<ReferenceNodeEditorProps> = ({ changeNodeType }) =
   });
   const styles = useStyles();
 
-  const selectNodeType = useCallback(
-    (event: ChangeEvent<{ value: string }>): void => {
-      changeNodeType(event?.target.value || '');
-    },
-    [changeNodeType]
-  );
-
   const showReference = useCallback((): void => {
     const pathwayReferenceId = (currentNode as ReferenceNode).referenceId;
     const referencedPathway = pathways.find(pathway => {
@@ -47,8 +40,7 @@ const ReferenceNodeEditor: FC<ReferenceNodeEditorProps> = ({ changeNodeType }) =
   }, [currentNode, pathways, setCurrentPathway]);
 
   const selectPathwayReference = useCallback(
-    (event: ChangeEvent<{ value: string }>): void => {
-      const referenceId = event?.target.value || '';
+    (referenceId: string): void => {
       const referenceLabel =
         pathwayOptions.find(option => {
           return option.value === referenceId;
@@ -77,7 +69,7 @@ const ReferenceNodeEditor: FC<ReferenceNodeEditorProps> = ({ changeNodeType }) =
               id="nodeType"
               label="Node Type"
               options={nodeTypeOptions}
-              onChange={selectNodeType}
+              onChange={changeNodeType}
               value="Reference"
             />
             <div className={styles.referenceDropdown}>

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React, { FC, memo, useCallback, useState, useRef, ChangeEvent } from 'react';
+import React, { FC, memo, useCallback, useState, useRef } from 'react';
 import { useHistory } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faChevronLeft, faChevronRight, faPlus } from '@fortawesome/free-solid-svg-icons';
@@ -38,13 +38,6 @@ const Sidebar: FC = () => {
         setCurrentPathway(setNodeType(pathwayRef.current, currentNodeRef.current.key, nodeType));
     },
     [pathwayRef, setCurrentPathway, currentNodeRef]
-  );
-
-  const selectNodeType = useCallback(
-    (event: ChangeEvent<{ value: string }>): void => {
-      changeNodeType(event?.target.value || '');
-    },
-    [changeNodeType]
   );
 
   const addPathwayNode = useCallback((): void => {
@@ -104,7 +97,7 @@ const Sidebar: FC = () => {
                 id="nodeType"
                 label="Node Type"
                 options={nodeTypeOptions}
-                onChange={selectNodeType}
+                onChange={changeNodeType}
                 value=""
               />
             )}
@@ -116,7 +109,7 @@ const Sidebar: FC = () => {
                 id="nodeType"
                 label="Node Type"
                 options={nodeTypeOptions}
-                onChange={selectNodeType}
+                onChange={changeNodeType}
                 value="Observation"
               />
             )}

--- a/src/components/Sidebar/styles.tsx
+++ b/src/components/Sidebar/styles.tsx
@@ -206,6 +206,9 @@ export default makeStyles(
       fontSize: '1em',
       fontStyle: 'italic',
       textTransform: 'none'
+    },
+    criteriaText: {
+      width: '100%'
     }
   }),
   { name: 'Sidebar', index: 1 }

--- a/src/components/Sidebar/styles.tsx
+++ b/src/components/Sidebar/styles.tsx
@@ -89,10 +89,7 @@ export default makeStyles(
     outlinedDiv: {
       display: 'flex',
       flexDirection: 'column',
-      alignItems: 'flex-start',
-      '& div': {
-        width: '100%'
-      }
+      alignItems: 'flex-start'
     },
     outlinedDivError: {
       borderColor: `${theme.palette.error.main} !important`,

--- a/src/components/elements/DropDown/DropDown.tsx
+++ b/src/components/elements/DropDown/DropDown.tsx
@@ -61,7 +61,12 @@ const DropDown: FC<DropDownProps> = ({
           </div>
         )}
         renderInput={(params): ReactElement => (
-          <TextField {...params} variant="outlined" label={label} />
+          <TextField
+            error={value == null || value === ''}
+            {...params}
+            variant="outlined"
+            label={label}
+          />
         )}
       />
     );

--- a/src/components/elements/DropDown/DropDown.tsx
+++ b/src/components/elements/DropDown/DropDown.tsx
@@ -74,7 +74,7 @@ const DropDown: FC<DropDownProps> = ({
 
   const renderManual = (): ReactElement => {
     return (
-      <>
+      <FormControl variant="outlined" fullWidth>
         <InputLabel id={id} htmlFor={`${id}-select`}>
           {label}
         </InputLabel>
@@ -104,15 +104,11 @@ const DropDown: FC<DropDownProps> = ({
             </MenuItem>
           ))}
         </Select>
-      </>
+      </FormControl>
     );
   };
 
-  return (
-    <FormControl variant="outlined" fullWidth>
-      {autocomplete ? renderAuto() : renderManual()}
-    </FormControl>
-  );
+  return <>{autocomplete ? renderAuto() : renderManual()}</>;
 };
 
 export default memo(DropDown);

--- a/src/components/elements/DropDown/DropDown.tsx
+++ b/src/components/elements/DropDown/DropDown.tsx
@@ -34,27 +34,24 @@ const DropDown: FC<DropDownProps> = ({
   );
 
   const handleAutoSelected = useCallback(
-    (event: ChangeEvent<{}>, value: Option): void => {
-      if (onChange) onChange(value.value);
+    (event: ChangeEvent<{}>, value: Option | null): void => {
+      if (onChange && value) onChange(value.value);
     },
     [onChange]
   );
 
   const getValue = (value: string | undefined): Option | undefined => {
-    return (
-      options.find(option => {
-        return option.value === value;
-      }) || options[0]
-    );
+    return options.find(option => {
+      return option.value === value;
+    });
   };
 
   const renderAuto = (): ReactElement => {
     return (
       <Autocomplete
-        disableClearable
         fullWidth
         onChange={handleAutoSelected}
-        value={getValue(value)}
+        value={getValue(value) || null}
         popupIcon={<FontAwesomeIcon icon={faCaretDown} style={{ color: 'white' }} />}
         options={options}
         getOptionLabel={(option): string => option.label}

--- a/src/components/elements/DropDown/DropDown.tsx
+++ b/src/components/elements/DropDown/DropDown.tsx
@@ -1,5 +1,8 @@
-import React, { FC, memo, useCallback, ChangeEvent } from 'react';
-import { InputLabel, FormControl, Select, MenuItem } from '@material-ui/core';
+import React, { FC, memo, useCallback, ChangeEvent, ReactElement } from 'react';
+import { InputLabel, FormControl, TextField, Select, MenuItem } from '@material-ui/core';
+import { faCaretDown } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Autocomplete } from '@material-ui/lab';
 
 interface Option {
   label: string;
@@ -12,47 +15,100 @@ interface DropDownProps {
   options: Array<Option>;
   value?: string;
   onChange: Function | null;
+  autocomplete?: boolean;
 }
 
-const DropDown: FC<DropDownProps> = ({ id, label, options, value, onChange }: DropDownProps) => {
+const DropDown: FC<DropDownProps> = ({
+  id,
+  label,
+  options,
+  value,
+  onChange,
+  autocomplete = true
+}: DropDownProps) => {
   const handleSetSelected = useCallback(
     (event: ChangeEvent<{ value: unknown }>): void => {
-      if (onChange) onChange(event);
+      if (onChange) onChange(event.target.value || '');
     },
     [onChange]
   );
 
+  const handleAutoSelected = useCallback(
+    (event: ChangeEvent<{}>, value: Option): void => {
+      if (onChange) onChange(value.value);
+    },
+    [onChange]
+  );
+
+  const getValue = (value: string | undefined): Option | undefined => {
+    return (
+      options.find(option => {
+        return option.value === value;
+      }) || options[0]
+    );
+  };
+
+  const renderAuto = (): ReactElement => {
+    return (
+      <Autocomplete
+        disableClearable
+        fullWidth
+        onChange={handleAutoSelected}
+        value={getValue(value)}
+        popupIcon={<FontAwesomeIcon icon={faCaretDown} style={{ color: 'white' }} />}
+        options={options}
+        getOptionLabel={(option): string => option.label}
+        renderOption={(option: Option): ReactElement => (
+          <div key={option.value} style={{ color: 'black' }}>
+            {option.label}
+          </div>
+        )}
+        renderInput={(params): ReactElement => (
+          <TextField {...params} variant="outlined" label={label} />
+        )}
+      />
+    );
+  };
+
+  const renderManual = (): ReactElement => {
+    return (
+      <>
+        <InputLabel id={id} htmlFor={`${id}-select`}>
+          {label}
+        </InputLabel>
+
+        <Select
+          id={`${id}-select`}
+          value={value || ''}
+          onChange={handleSetSelected}
+          label={label}
+          error={value == null || value === ''}
+          MenuProps={{
+            getContentAnchorEl: null,
+            anchorOrigin: {
+              vertical: 'bottom',
+              horizontal: 'center'
+            },
+            transformOrigin: {
+              vertical: 'top',
+              horizontal: 'center'
+            }
+          }}
+          displayEmpty
+        >
+          {options.map(option => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </Select>
+      </>
+    );
+  };
+
   return (
     <FormControl variant="outlined" fullWidth>
-      <InputLabel id={id} htmlFor={`${id}-select`}>
-        {label}
-      </InputLabel>
-
-      <Select
-        id={`${id}-select`}
-        value={value || ''}
-        onChange={handleSetSelected}
-        label={label}
-        error={value == null || value === ''}
-        MenuProps={{
-          getContentAnchorEl: null,
-          anchorOrigin: {
-            vertical: 'bottom',
-            horizontal: 'center'
-          },
-          transformOrigin: {
-            vertical: 'top',
-            horizontal: 'center'
-          }
-        }}
-        displayEmpty
-      >
-        {options.map(option => (
-          <MenuItem key={option.value} value={option.value}>
-            {option.label}
-          </MenuItem>
-        ))}
-      </Select>
+      {autocomplete ? renderAuto() : renderManual()}
     </FormControl>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1377,6 +1377,17 @@
     react-is "^16.8.0"
     react-transition-group "^4.3.0"
 
+"@material-ui/lab@^4.0.0-alpha.56":
+  version "4.0.0-alpha.56"
+  resolved "https://registry.yarnpkg.com/@material-ui/lab/-/lab-4.0.0-alpha.56.tgz#ff63080949b55b40625e056bbda05e130d216d34"
+  integrity sha512-xPlkK+z/6y/24ka4gVJgwPfoCF4RCh8dXb1BNE7MtF9bXEBLN/lBxNTK8VAa0qm3V2oinA6xtUIdcRh0aeRtVw==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@material-ui/utils" "^4.10.2"
+    clsx "^1.0.4"
+    prop-types "^15.7.2"
+    react-is "^16.8.0"
+
 "@material-ui/styles@^4.9.10":
   version "4.9.10"
   resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.9.10.tgz#182ccdd0bc8525a459486499bbaebcd92b0db3ab"
@@ -1412,6 +1423,15 @@
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@material-ui/types/-/types-5.0.1.tgz#c4954063cdc196eb327ee62c041368b1aebb6d61"
   integrity sha512-wURPSY7/3+MAtng3i26g+WKwwNE3HEeqa/trDBR5+zWKmcjO+u9t7Npu/J1r+3dmIa/OeziN9D/18IrBKvKffw==
+
+"@material-ui/utils@^4.10.2":
+  version "4.10.2"
+  resolved "https://registry.yarnpkg.com/@material-ui/utils/-/utils-4.10.2.tgz#3fd5470ca61b7341f1e0468ac8f29a70bf6df321"
+  integrity sha512-eg29v74P7W5r6a4tWWDAAfZldXIzfyO1am2fIsC39hdUUHm/33k6pGOKPbgDjg/U/4ifmgAePy/1OjkKN6rFRw==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    prop-types "^15.7.2"
+    react-is "^16.8.0"
 
 "@material-ui/utils@^4.9.6":
   version "4.9.6"


### PR DESCRIPTION
This uses the the material UI Autocomplete component to make our dropdowns searchable.  The only thing to note is that the pattern where dropdowns would have helper functions to extract the `events.target.value` has been gotten rid of.  I thought it was a bad pattern to begin with, but the autocomplete component also doesn't return an event with a value, it returns the value itself, so the `onChange` function needed to change to accept just the raw value string.  This just means that the helper functions in other components were removed.

You can test that everything works by typing in a value and selecting from the list.   