### PR TITLE
Fix Undo stack when loading pathway by url

### DIFF
--- a/src/components/CurrentPathwayProvider.tsx
+++ b/src/components/CurrentPathwayProvider.tsx
@@ -13,7 +13,7 @@ import useRefUndoState from 'hooks/useRefUndoState';
 import { usePathwaysContext } from './PathwaysProvider';
 import HotKeys from 'react-hot-keys';
 import { useCriteriaContext } from './CriteriaProvider';
-import { addCriteriaSourceToPathway } from 'utils/builder';
+import { updatePathwayCriteriaSources } from 'utils/builder';
 
 interface CurrentPathwayContextInterface {
   pathway: Pathway | null;
@@ -78,7 +78,7 @@ export const CurrentPathwayProvider: FC<CurrentPathwayProviderProps> = memo(({ c
   useEffect(() => {
     if (!pathway) return;
 
-    const { updated, newPathway } = addCriteriaSourceToPathway(pathway, criteria);
+    const { updated, newPathway } = updatePathwayCriteriaSources(pathway, criteria);
     if (updated) resetCurrentPathway(newPathway);
   }, [criteria, pathway, resetCurrentPathway]);
 

--- a/src/components/CurrentPathwayProvider.tsx
+++ b/src/components/CurrentPathwayProvider.tsx
@@ -78,6 +78,7 @@ export const CurrentPathwayProvider: FC<CurrentPathwayProviderProps> = memo(({ c
   useEffect(() => {
     if (!pathway) return;
 
+    let updated = false;
     const criteriaIds = criteria.map(crit => crit.id);
     const newPathway = produce(pathway, draftPathway => {
       Object.entries(draftPathway.nodes).forEach(([nodeIndex, node]) => {
@@ -92,13 +93,16 @@ export const CurrentPathwayProvider: FC<CurrentPathwayProviderProps> = memo(({ c
             if (criteriaSource) {
               const condition =
                 draftPathway.nodes[nodeIndex].transitions[transitionIndex].condition;
-              if (condition) condition.criteriaSource = criteriaSource;
+              if (condition) {
+                updated = true;
+                condition.criteriaSource = criteriaSource;
+              }
             }
           }
         });
       });
     });
-    resetCurrentPathway(newPathway);
+    if (updated) resetCurrentPathway(newPathway);
   }, [criteria, pathway, resetCurrentPathway]);
 
   return (

--- a/src/utils/builder.ts
+++ b/src/utils/builder.ts
@@ -35,28 +35,73 @@ export function createNewPathway(name: string, description: string, pathwayId?: 
   };
 }
 
+interface AddCriteriaSourceInterface {
+  updated: boolean;
+  newPathway: Pathway;
+}
+
+export function addCriteriaSourceToPathway(
+  pathway: Pathway,
+  criteria: Criteria[]
+): AddCriteriaSourceInterface {
+  let updated = false;
+  const criteriaIds = criteria.map(crit => crit.id);
+  const newPathway = produce(pathway, draftPathway => {
+    Object.entries(draftPathway.nodes).forEach(([nodeIndex, node]) => {
+      node.transitions.forEach(({ condition }, transitionIndex) => {
+        // If a matching criteria does not already exist, try and find one
+        if (condition && !criteriaIds.includes(condition.criteriaSource as string)) {
+          const [library, statement] = condition.cql.split('.');
+          const criteriaSource = criteria.find(
+            crit => crit.elm?.library.identifier.id === library && crit.statement === statement
+          )?.id;
+          // Only update if a criteria source is actually found.
+          if (criteriaSource) {
+            const condition = draftPathway.nodes[nodeIndex].transitions[transitionIndex].condition;
+            if (condition) {
+              updated = true;
+              condition.criteriaSource = criteriaSource;
+            }
+          }
+        }
+      });
+    });
+  });
+  return { updated, newPathway };
+}
+
+function addCriteriaSource(pathways: Pathway[], criteria: Criteria[]): Pathway[] {
+  const newPathways: Pathway[] = [];
+  pathways.forEach(pathway => {
+    const { newPathway } = addCriteriaSourceToPathway(pathway, criteria);
+    newPathways.push(newPathway);
+  });
+  return newPathways;
+}
+
 export function downloadPathway(
-  pathway: Pathway[],
-  pathways: Pathway[],
+  pathwaysToExport: Pathway[],
+  allPathways: Pathway[],
   criteria: Criteria[],
   cpg = false
 ): Promise<void> {
-  if (pathway.length > 1) {
+  pathwaysToExport = addCriteriaSource(pathwaysToExport, criteria);
+  if (pathwaysToExport.length > 1) {
     const zip = new JSZip();
     // If multiple pathways are being exported
-    pathway.forEach(path => {
-      zip.file(`${path.name}.json`, exportPathway(path, pathways, criteria, cpg));
+    pathwaysToExport.forEach(path => {
+      zip.file(`${path.name}.json`, exportPathway(path, allPathways, criteria, cpg));
     });
     return zip.generateAsync({ type: 'blob' }).then(function(content) {
       downloadFile(content, 'pathways.zip');
     });
   } else {
-    const pathwayString = exportPathway(pathway[0], pathways, criteria, cpg);
+    const pathwayString = exportPathway(pathwaysToExport[0], allPathways, criteria, cpg);
     // Create blob from pathwayString to save to file system
     const pathwayBlob = new Blob([pathwayString], {
       type: 'application/json'
     });
-    downloadFile(pathwayBlob, `${pathway[0].name}.json`);
+    downloadFile(pathwayBlob, `${pathwaysToExport[0].name}.json`);
     return Promise.resolve();
   }
 }

--- a/src/utils/builder.ts
+++ b/src/utils/builder.ts
@@ -40,7 +40,7 @@ interface AddCriteriaSourceInterface {
   newPathway: Pathway;
 }
 
-export function addCriteriaSourceToPathway(
+export function updatePathwayCriteriaSources(
   pathway: Pathway,
   criteria: Criteria[]
 ): AddCriteriaSourceInterface {
@@ -71,12 +71,7 @@ export function addCriteriaSourceToPathway(
 }
 
 function addCriteriaSource(pathways: Pathway[], criteria: Criteria[]): Pathway[] {
-  const newPathways: Pathway[] = [];
-  pathways.forEach(pathway => {
-    const { newPathway } = addCriteriaSourceToPathway(pathway, criteria);
-    newPathways.push(newPathway);
-  });
-  return newPathways;
+  return pathways.map(pathway => updatePathwayCriteriaSources(pathway, criteria).newPathway);
 }
 
 export function downloadPathway(


### PR DESCRIPTION
Previously when loading a pathway by url there was already something on the undo stack (https://mcode.github.io/pathway-builder/#/builder/eNPAgToBD/node/TumorSize). 

This was due to `criteriaSource` being set in the `PathwaysProvider`. The pathway would load but then `criteriaSource` would be set and update the pathway adding to the undo stack. 

Solution: Move the useEffect hook to the currentPathway. You can check this works by validating (https://mcode.github.io/pathway-builder/#/builder/eNPAgToBD/node/TumorSize):
1. The criteria source is still set in the sidebar 
2. There is nothing on the undo stack (can't undo)

Notes: While this fixes the issue (and removes the code from PatwhaysProvider which was going to happen in my integrate backend task anyway) there are numerous outstanding issues:
1. This is not very efficient as it will check the current pathway every time the pathway changes or the criteria changes. Note the pathway will not be reset so react will not re-render but it will still loop through all edges of the pathway on each change. Regardless this is still better than the previous solution which looped through every edge of every pathway on every change.
2. The reason this chunk of code exists is because criteriaIds change every time the page loads (and it loads the criteria from the static files). We should probably investigate a way of having deterministic ids every time (when pulling from the backend this should not be a problem because it is loading in a criteria object and not creating a criteria object from static files). The easiest way would be to have the app load json files of the criteria data model instead of re-importing every time.
3. Whenever criteria is deleted there is currently no check to make sure that it is safe. Here, like I am sure in other places in the builder, deleting the referenced item will result in a dangling reference.