### PR TITLE
Support for importing CQL reference libraries

### DIFF
--- a/src/components/CriteriaList/CriteriaList.tsx
+++ b/src/components/CriteriaList/CriteriaList.tsx
@@ -108,7 +108,7 @@ const CriteriaList: FC = () => {
         open={open}
         onClose={closeImportModal}
         onSelectFile={selectFile}
-        allowedFileType=".cql"
+        allowedFileType=".cql, .zip"
       />
 
       {status === 'loading' ? (

--- a/src/components/CriteriaProvider/CriteriaProvider.tsx
+++ b/src/components/CriteriaProvider/CriteriaProvider.tsx
@@ -50,6 +50,7 @@ const DEFAULT_ELM_STATEMENTS = [
 const CQL_HELPER_LIBRARIES = [
   'FHIRHelpers.cql',
   'CDS_Connect_Commons_for_FHIRv400.cql',
+  'CDS_Connect_Commons_for_FHIRv401.cql',
   'CDS_Connect_Conversions.cql'
 ];
 
@@ -183,10 +184,19 @@ export const CriteriaProvider: FC<CriteriaProviderProps> = memo(({ children }) =
 
               // Skip files that do not end with .cql
               if (!zipFile.name.endsWith('.cql')) continue;
+
               const fileContents = await zipFile.async('string');
               if (CQL_HELPER_LIBRARIES.includes(zipFile.name)) {
                 cqlObj.libraries[zipFile.name] = { cql: fileContents };
               } else {
+                if (cqlObj.main) {
+                  console.error(
+                    `cqlObj.main is already set, files in zip are ${zipFiles
+                      .map(z => z.name)
+                      .join(', ')}`
+                  );
+                  alert('cqlObj.main is already set.');
+                }
                 cqlObj.main = fileContents;
               }
             }

--- a/src/components/CriteriaProvider/CriteriaProvider.tsx
+++ b/src/components/CriteriaProvider/CriteriaProvider.tsx
@@ -47,6 +47,12 @@ const DEFAULT_ELM_STATEMENTS = [
   'Errors'
 ];
 
+const CQL_HELPER_LIBRARIES = [
+  'FHIRHelpers.cql',
+  'CDS_Connect_Commons_for_FHIRv400.cql',
+  'CDS_Connect_Conversions.cql'
+];
+
 function builderModelToCriteria(criteria: BuilderModel, label: string): Criteria {
   return {
     id: shortid.generate(),
@@ -173,10 +179,13 @@ export const CriteriaProvider: FC<CriteriaProviderProps> = memo(({ children }) =
             const zipFiles = Object.values(zip.files);
             // Check for criteria in each of the cql files, add cql to libraries if no criteria
             for (let i = 0; i < zipFiles.length; i++) {
-              const fileContents = await zipFiles[i].async('string');
-              const criteria = await cqlToCriteria(fileContents);
-              if (criteria.length === 0) {
-                cqlObj.libraries[zipFiles[i].name] = { cql: fileContents };
+              const zipFile = zipFiles[i];
+
+              // Skip files that do not end with .cql
+              if (!zipFile.name.endsWith('.cql')) continue;
+              const fileContents = await zipFile.async('string');
+              if (CQL_HELPER_LIBRARIES.includes(zipFile.name)) {
+                cqlObj.libraries[zipFile.name] = { cql: fileContents };
               } else {
                 cqlObj.main = fileContents;
               }

--- a/src/components/CriteriaProvider/CriteriaProvider.tsx
+++ b/src/components/CriteriaProvider/CriteriaProvider.tsx
@@ -9,6 +9,7 @@ import React, {
   useEffect
 } from 'react';
 import shortid from 'shortid';
+import JSZip from 'jszip';
 import { ElmStatement, ElmLibrary } from 'elm-model';
 import config from 'utils/ConfigManager';
 import useGetService from 'components/Services';
@@ -154,6 +155,14 @@ export const CriteriaProvider: FC<CriteriaProviderProps> = memo(({ children }) =
             if (newCriteria) setCriteria(currentCriteria => [...currentCriteria, ...newCriteria]);
           } else if (file.name.endsWith('.cql')) {
             addCqlCriteria(rawContent);
+          } else if (file.name.endsWith('.zip')) {
+            JSZip.loadAsync(file).then(zip => {
+              Object.values(zip.files).forEach(file => {
+                file.async('string').then(fileContents => {
+                  addCqlCriteria(fileContents);
+                });
+              });
+            });
           }
         } else alert('Unable to read that file');
       };

--- a/src/engine/cql-to-elm.ts
+++ b/src/engine/cql-to-elm.ts
@@ -11,11 +11,9 @@ const url = config.get('cqlToElmWebserviceUrl');
 
 export interface CqlObject {
   main: string;
-  libraries: Library;
-}
-
-export interface Library {
-  [name: string]: string; // should probably have an object for expected ELM structure.
+  libraries: {
+    [name: string]: string;
+  };
 }
 
 export interface ElmObject {

--- a/src/engine/cql-to-elm.ts
+++ b/src/engine/cql-to-elm.ts
@@ -1,8 +1,73 @@
 // External CQL -> ELM service
 import config from 'utils/ConfigManager';
+import {
+  extractJSONContent,
+  extractMultipartBoundary,
+  extractMultipartFileName
+} from 'utils/regexes';
 import { ElmLibrary } from 'elm-model';
 
 const url = config.get('cqlToElmWebserviceUrl');
+
+export interface CqlObject {
+  main: string;
+  libraries: Library;
+}
+
+export interface Library {
+  [name: string]: string; // should probably have an object for expected ELM structure.
+}
+
+export interface ElmObject {
+  main: object;
+  libraries: {
+    [key: string]: object;
+  };
+}
+
+/**
+ * Function that requests web_service to convert the cql into elm.
+ * @param cql - cql file that is the input to the function.
+ * @return The resulting elm translation of the cql file.
+ */
+export function convertCQL(cql: CqlObject): Promise<ElmLibrary> {
+  // Connect to web service
+  const formdata = new FormData();
+  Object.keys(cql.libraries).forEach((key, i) => {
+    formdata.append(`${key}`, cql.libraries[key]);
+  });
+
+  formdata.append('main', cql.main);
+  return fetch(url, {
+    method: 'POST',
+    body: formdata
+  }).then(elm => {
+    const header = elm.headers.get('content-type');
+    let boundary = '';
+    if (header) {
+      // sample header= "multipart/form-data;boundary=Boundary_1"
+      const result = extractMultipartBoundary.exec(header);
+      boundary = result ? `--${result[1]}` : '';
+    }
+    const obj: ElmObject = { main: {}, libraries: {} };
+    return elm.text().then(text => {
+      const elms = text.split(boundary).reduce((oldArray, line, i) => {
+        const body = extractJSONContent.exec(line);
+        if (body) {
+          const elmName = extractMultipartFileName.exec(line);
+          if (elmName && elmName[1] === 'main') {
+            oldArray[elmName[1]] = JSON.parse(body[1]);
+          } else if (elmName) {
+            oldArray.libraries[elmName[1]] = JSON.parse(body[1]);
+          }
+        }
+        return oldArray;
+      }, obj);
+
+      return elms.main as ElmLibrary;
+    });
+  });
+}
 
 export function convertBasicCQL(cql: string): Promise<ElmLibrary> {
   // Connect to web service

--- a/src/engine/cql-to-elm.ts
+++ b/src/engine/cql-to-elm.ts
@@ -11,8 +11,13 @@ const url = config.get('cqlToElmWebserviceUrl');
 
 export interface CqlObject {
   main: string;
-  libraries: {
-    [name: string]: string;
+  libraries: CqlLibrary;
+}
+
+export interface CqlLibrary {
+  [name: string]: {
+    cql?: string;
+    version?: string;
   };
 }
 
@@ -28,11 +33,14 @@ export interface ElmObject {
  * @param cql - cql file that is the input to the function.
  * @return The resulting elm translation of the cql file.
  */
-export function convertCQL(cql: CqlObject): Promise<ElmLibrary> {
+export function convertCQL(cql: CqlObject): Promise<ElmObject> {
   // Connect to web service
   const formdata = new FormData();
   Object.keys(cql.libraries).forEach((key, i) => {
-    formdata.append(`${key}`, cql.libraries[key]);
+    const cqlLibrary = cql.libraries[key];
+    if (cqlLibrary.cql) {
+      formdata.append(`${key}`, cqlLibrary.cql);
+    }
   });
 
   formdata.append('main', cql.main);
@@ -62,7 +70,7 @@ export function convertCQL(cql: CqlObject): Promise<ElmLibrary> {
         return oldArray;
       }, obj);
 
-      return elms.main as ElmLibrary;
+      return elms;
     });
   });
 }

--- a/src/types/criteria-model.d.ts
+++ b/src/types/criteria-model.d.ts
@@ -7,7 +7,12 @@ declare module 'criteria-model' {
     version?: string;
     modified: number;
     statement: string;
-    cqlLibraries?: { [name: string]: string };
+    cqlLibraries?: {
+      [name: string]: {
+        cql?: string;
+        version?: string;
+      };
+    };
   }
 
   interface Gender {

--- a/src/types/criteria-model.d.ts
+++ b/src/types/criteria-model.d.ts
@@ -7,6 +7,7 @@ declare module 'criteria-model' {
     version?: string;
     modified: number;
     statement: string;
+    cqlLibraries?: { [name: string]: string };
   }
 
   interface Gender {

--- a/src/types/elm-model.d.ts
+++ b/src/types/elm-model.d.ts
@@ -1,4 +1,8 @@
 declare module 'elm-model' {
+  export interface ElmLibraries {
+    [key: string]: ElmLibrary;
+  }
+
   export interface ElmLibrary {
     library: {
       identifier: {

--- a/src/utils/CaminoExporter.ts
+++ b/src/utils/CaminoExporter.ts
@@ -46,6 +46,19 @@ export class CaminoExporter {
 
             referencedDefines[transition.condition.cql] = libraryIdentifier.id;
 
+            if (criteriaSource?.cqlLibraries) {
+              Object.entries(criteriaSource.cqlLibraries).forEach(entry => {
+                const [libName, libCql] = entry;
+                if (libCql.cql) {
+                  includedCqlLibraries[libName] = {
+                    cql: libCql.cql,
+                    version: libCql?.version || ''
+                  };
+                  referencedDefines[libCql.cql] = libName;
+                }
+              });
+            }
+
             // prepend the library name if not already done
             if (!transition.condition.cql.startsWith(libraryIdentifier.id)) {
               transition.condition.cql = `${libraryIdentifier.id}.${transition.condition.cql}`;

--- a/src/utils/cpg.ts
+++ b/src/utils/cpg.ts
@@ -345,6 +345,18 @@ export class CPGExporter {
             };
 
             referencedDefines[transition.condition.cql] = libraryIdentifier.id;
+
+            if (criteriaSource?.cqlLibraries) {
+              Object.entries(criteriaSource.cqlLibraries).forEach(entry => {
+                const [libName, libCql] = entry;
+                includedCqlLibraries[libName] = {
+                  cql: libCql,
+                  // TODO: get actual version
+                  version: '1.0.0'
+                };
+                referencedDefines[libCql] = libName;
+              });
+            }
           } else if (criteriaSource?.builder) {
             builderDefines[criteriaSource.statement] = criteriaSource.builder.cql;
           }

--- a/src/utils/cpg.ts
+++ b/src/utils/cpg.ts
@@ -349,12 +349,13 @@ export class CPGExporter {
             if (criteriaSource?.cqlLibraries) {
               Object.entries(criteriaSource.cqlLibraries).forEach(entry => {
                 const [libName, libCql] = entry;
-                includedCqlLibraries[libName] = {
-                  cql: libCql,
-                  // TODO: get actual version
-                  version: '1.0.0'
-                };
-                referencedDefines[libCql] = libName;
+                if (libCql.cql) {
+                  includedCqlLibraries[libName] = {
+                    cql: libCql.cql,
+                    version: libCql?.version || ''
+                  };
+                  referencedDefines[libCql.cql] = libName;
+                }
               });
             }
           } else if (criteriaSource?.builder) {

--- a/src/utils/regexes.ts
+++ b/src/utils/regexes.ts
@@ -1,6 +1,6 @@
 // sample header= "multipart/form-data;boundary=Boundary_1"
 // get the part after "boundary=" and before any subsequent ;
-export const extractMultipartBoundary = /.*;boundary=(Boundary.*);?.*/g;
+export const extractMultipartBoundary = /.*;boundary=(Boundary.*);?.*/;
 
 export const extractMultipartFileName = /Content-Disposition: form-data; name="([^"]+)"/;
 


### PR DESCRIPTION
You can now import a zip file, containing multiple CQL files.
    - Checks each cql file for criteria, if no criteria is present the file will be treated as a reference library.
    - Re-added `convertCQL` function to pass the libraries to the cql-to-elm webservice.
    - Added `cqlLibraries` property to criteria model to keep track of the reference libraries each criteria needs to run.

I still need to test output with cqf-ruler.