### PR TITLE
Convert CQL to ELM only once

### DIFF
--- a/src/components/CriteriaBuilderProvider.tsx
+++ b/src/components/CriteriaBuilderProvider.tsx
@@ -7,7 +7,7 @@ import React, {
   FC,
   useContext
 } from 'react';
-import { BuilderModel } from 'criteria-model';
+import { CriteriaExecutionModel } from 'criteria-model';
 
 interface CriteriaBuilderContextInterface {
   selectedElement: string;
@@ -21,7 +21,7 @@ interface CriteriaBuilderContextInterface {
   setMinimumAge: (age: number) => void;
   setMaximumAge: (age: number) => void;
   resetCriteriaBuilder: () => void;
-  setCriteriaBuilder: (buildCriteria: BuilderModel) => void;
+  setCriteriaBuilder: (buildCriteria: CriteriaExecutionModel) => void;
 }
 
 export const CriteriaBuilderContext = createContext<CriteriaBuilderContextInterface>(
@@ -47,15 +47,15 @@ export const CriteriaBuilderProvider: FC<CriteriaBuilderProviderProps> = memo(({
     setMaximumAge(0);
   }, [setSelectedElement, setSelectedDemoElement, setGender, setMinimumAge, setMaximumAge]);
 
-  const setCriteriaBuilder = useCallback((buildCriteria: BuilderModel) => {
+  const setCriteriaBuilder = useCallback((buildCriteria: CriteriaExecutionModel) => {
     setSelectedElement('Demographics');
-    if (buildCriteria.type === 'gender') {
+    if (buildCriteria.builder?.type === 'gender') {
       setSelectedDemoElement('Gender');
-      setGender(buildCriteria.gender);
-    } else {
+      setGender(buildCriteria.builder.gender);
+    } else if (buildCriteria.builder?.type === 'age') {
       setSelectedDemoElement('Age Range');
-      setMinimumAge(buildCriteria.min);
-      setMaximumAge(buildCriteria.max);
+      setMinimumAge(buildCriteria.builder.min);
+      setMaximumAge(buildCriteria.builder.max);
     }
   }, []);
 

--- a/src/components/CriteriaList/CriteriaList.tsx
+++ b/src/components/CriteriaList/CriteriaList.tsx
@@ -12,7 +12,7 @@ import FileImportModal from 'components/FileImportModal';
 import useListCheckbox from 'hooks/useListCheckbox';
 import ConfirmationPopover from 'components/elements/ConfirmationPopover';
 import { deleteCriteria, readFile, updateCriteria } from 'utils/backend';
-import { cqlToCriteria, jsonToCriteria } from 'utils/criteria';
+import { cqlToCriteria } from 'utils/criteria';
 import useCriteria from 'hooks/useCriteria';
 import JSZip from 'jszip';
 import { CqlLibraries } from 'engine/cql-to-elm';
@@ -64,10 +64,7 @@ const CriteriaList: FC = () => {
           if (event.target?.result) {
             const rawContent = event.target.result as string;
             // TODO: more robust file type identification?
-            if (files[0].name.endsWith('.json')) {
-              const newCriteria = jsonToCriteria(rawContent);
-              if (newCriteria) newCriteria.forEach(criteria => mutateAddCriteria(criteria)); // eslint-disable-line
-            } else if (files[0].name.endsWith('.cql')) {
+            if (files[0].name.endsWith('.cql')) {
               addCqlCriteria(rawContent);
             } else if (files[0].name.endsWith('.zip')) {
               const cqlLibraries: CqlLibraries = {};
@@ -90,7 +87,7 @@ const CriteriaList: FC = () => {
       }
       closeImportModal();
     },
-    [mutateAddCriteria, closeImportModal, addCqlCriteria]
+    [closeImportModal, addCqlCriteria]
   );
 
   const [mutateDelete] = useMutation(deleteCriteria, {

--- a/src/components/CurrentCriteriaProvider.tsx
+++ b/src/components/CurrentCriteriaProvider.tsx
@@ -8,16 +8,16 @@ import React, {
   useCallback
 } from 'react';
 
-import { BuilderModel } from 'criteria-model';
+import { CriteriaExecutionModel } from 'criteria-model';
 
 interface CurrentCriteriaContextInterface {
   buildCriteriaSelected: boolean;
   currentCriteriaNodeId: string;
-  currentCriteria: BuilderModel | null;
+  currentCriteria: CriteriaExecutionModel | null;
   criteriaName: string;
   setBuildCriteriaSelected: (buildCriteriaSelect: boolean) => void;
   setCurrentCriteriaNodeId: (id: string) => void;
-  setCurrentCriteria: (currentCriteria: BuilderModel | null) => void;
+  setCurrentCriteria: (currentCriteria: CriteriaExecutionModel | null) => void;
   setCriteriaName: (criteriaName: string) => void;
   resetCurrentCriteria: () => void;
 }
@@ -32,7 +32,7 @@ interface CurrentCriteriaProviderProps {
 
 export const CurrentCriteriaProvider: FC<CurrentCriteriaProviderProps> = memo(({ children }) => {
   const [currentCriteriaNodeId, setCurrentCriteriaNodeId] = useState<string>('');
-  const [currentCriteria, setCurrentCriteria] = useState<BuilderModel | null>(null);
+  const [currentCriteria, setCurrentCriteria] = useState<CriteriaExecutionModel | null>(null);
   const [buildCriteriaSelected, setBuildCriteriaSelected] = useState<boolean>(false);
   const [criteriaName, setCriteriaName] = useState<string>('');
 

--- a/src/components/Sidebar/ActionNodeEditor.tsx
+++ b/src/components/Sidebar/ActionNodeEditor.tsx
@@ -49,7 +49,7 @@ const ActionNodeEditor: FC<ActionNodeEditorProps> = ({ changeNodeType, currentNo
       convertBasicCQL(cql).then(elm => {
         // Disable lint for no-null assertion since it is already checked above
         // eslint-disable-next-line
-        setCurrentPathway(setActionNodeElm(pathwayRef.current!, currentNodeKey, elm));
+        //setCurrentPathway(setActionNodeElm(pathwayRef.current!, currentNodeKey, elm));
       });
     },
     [pathwayRef, setCurrentPathway]

--- a/src/components/Sidebar/ActionNodeEditor.tsx
+++ b/src/components/Sidebar/ActionNodeEditor.tsx
@@ -4,8 +4,6 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCheckCircle } from '@fortawesome/free-solid-svg-icons';
 import {
   setNodeAction,
-  createCQL,
-  setActionNodeElm,
   setActionResourceDisplay,
   setActionCode,
   setActionDescription,
@@ -16,7 +14,6 @@ import DropDown from 'components/elements/DropDown';
 import { ActionNode, Action, PathwayNode } from 'pathways-model';
 import useStyles from './styles';
 import { TextField } from '@material-ui/core';
-import { convertBasicCQL } from 'engine/cql-to-elm';
 import { useCurrentPathwayContext } from 'components/CurrentPathwayProvider';
 import produce from 'immer';
 import { nodeTypeOptions } from 'utils/nodeUtils';
@@ -40,20 +37,6 @@ const ActionNodeEditor: FC<ActionNodeEditorProps> = ({ changeNodeType, currentNo
   const { pathwayRef, setCurrentPathway } = useCurrentPathwayContext();
   const currentNodeStatic = useCurrentNodeStatic(pathwayRef.current) as ActionNode;
   const styles = useStyles();
-
-  const addActionCQL = useCallback(
-    (action: Action, currentNodeKey: string): void => {
-      if (!pathwayRef.current) return;
-
-      const cql = createCQL(action, currentNodeKey);
-      convertBasicCQL(cql).then(elm => {
-        // Disable lint for no-null assertion since it is already checked above
-        // eslint-disable-next-line
-        //setCurrentPathway(setActionNodeElm(pathwayRef.current!, currentNodeKey, elm));
-      });
-    },
-    [pathwayRef, setCurrentPathway]
-  );
 
   const changeCode = useCallback(
     (event: ChangeEvent<{ value: string }>): void => {
@@ -85,13 +68,16 @@ const ActionNodeEditor: FC<ActionNodeEditorProps> = ({ changeNodeType, currentNo
 
       const title = event?.target.value || '';
       const action = setActionTitle(currentNodeStatic.action, title);
-      setCurrentPathway(
-        setNodeAction(pathwayRef.current, currentNodeStatic.key, resetDisplay(action))
+
+      const pathway = setNodeAction(
+        pathwayRef.current,
+        currentNodeStatic.key,
+        resetDisplay(action)
       );
 
-      addActionCQL(action, currentNodeStatic.key);
+      setCurrentPathway(pathway);
     },
-    [currentNodeStatic, pathwayRef, setCurrentPathway, addActionCQL]
+    [currentNodeStatic, pathwayRef, setCurrentPathway]
   );
 
   const selectCodeSystem = useCallback(
@@ -113,11 +99,10 @@ const ActionNodeEditor: FC<ActionNodeEditorProps> = ({ changeNodeType, currentNo
     }
 
     const action = setActionResourceDisplay(currentNode.action, 'Example Text');
-    setCurrentPathway(setNodeAction(pathwayRef.current, currentNode.key, action));
+    const pathway = setNodeAction(pathwayRef.current, currentNode.key, action);
 
-    // TODO: move addActionCQL to builder.ts
-    addActionCQL(action, currentNode.key);
-  }, [currentNodeStatic, pathwayRef, setCurrentPathway, addActionCQL]);
+    setCurrentPathway(pathway);
+  }, [currentNodeStatic, pathwayRef, setCurrentPathway]);
 
   const resetDisplay = (action: Action): Action => {
     return produce(action, (draftAction: Action) => {

--- a/src/components/Sidebar/BranchTransition.tsx
+++ b/src/components/Sidebar/BranchTransition.tsx
@@ -14,7 +14,7 @@ import useStyles from './styles';
 import { useCurrentPathwayContext } from 'components/CurrentPathwayProvider';
 import { useCurrentCriteriaContext } from 'components/CurrentCriteriaProvider';
 import { useCriteriaBuilderContext } from 'components/CriteriaBuilderProvider';
-import { BuilderModel, Criteria } from 'criteria-model';
+import { Criteria, CriteriaExecutionModel } from 'criteria-model';
 import useCriteria from 'hooks/useCriteria';
 import { addBuilderCriteria } from 'utils/criteria';
 import useCurrentNodeStatic from 'hooks/useCurrentNodeStatic';
@@ -59,11 +59,16 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition, currentNode }
   const icon = hasCriteria ? <FontAwesomeIcon icon={faTrashAlt} /> : null;
   const transitionSelected = buildCriteriaSelected && currentCriteriaNodeId === transition.id;
   // Check if criteria was built by criteria builder
-  let builderElements: BuilderModel | null = null;
+  let builderElements: CriteriaExecutionModel | null = null;
   let builderCriteria: Criteria | undefined;
   if (transition.condition) {
     builderCriteria = criteria.find(c => c.id === transition.condition?.criteriaSource);
-    if (builderCriteria?.builder) builderElements = builderCriteria.builder;
+    if (builderCriteria?.builder)
+      builderElements = {
+        builder: builderCriteria.builder,
+        cql: builderCriteria.cql,
+        elm: builderCriteria.elm
+      };
   }
   const dislayEditCriteria = !transitionSelected && builderElements;
 
@@ -147,7 +152,7 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition, currentNode }
 
   const handleEditCriteria = useCallback((): void => {
     setCurrentCriteriaNodeId(transition.id);
-    setCurrentCriteria(builderElements as BuilderModel);
+    setCurrentCriteria(builderElements);
     if (builderCriteria?.label) setCriteriaName(builderCriteria?.label);
     if (!buildCriteriaSelected) setBuildCriteriaSelected(true);
     if (builderElements) setCriteriaBuilder(builderElements);
@@ -256,7 +261,7 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition, currentNode }
             fullWidth
             disabled
           />
-          <span className={styles.buildCriteriaText}>{builderElements?.text}</span>
+          <span className={styles.buildCriteriaText}>{builderElements?.builder?.text}</span>
           <div className={styles.buildCriteriaContainer}>
             <Button
               className={styles.cancelButton}
@@ -303,8 +308,8 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition, currentNode }
             value={criteriaName}
             fullWidth
           />
-          {currentCriteria?.text && (
-            <span className={styles.buildCriteriaText}>{currentCriteria.text}</span>
+          {currentCriteria?.builder?.text && (
+            <span className={styles.buildCriteriaText}>{currentCriteria.builder.text}</span>
           )}
           <div className={styles.buildCriteriaContainer}>
             <FormControlLabel

--- a/src/components/StaticApp/CriteriaProvider.tsx
+++ b/src/components/StaticApp/CriteriaProvider.tsx
@@ -9,17 +9,11 @@ import React, {
   useEffect
 } from 'react';
 import JSZip from 'jszip';
-import { ElmLibrary } from 'elm-model';
 import config from 'utils/ConfigManager';
 import useGetService from 'components/StaticApp/Services';
 import { ServiceLoaded } from 'pathways-objects';
-import { Criteria, BuilderModel } from 'criteria-model';
-import {
-  builderModelToCriteria,
-  cqlToCriteria,
-  elmLibraryToCriteria,
-  jsonToCriteria
-} from 'utils/criteria';
+import { Criteria, CriteriaExecutionModel } from 'criteria-model';
+import { builderModelToCriteria, cqlToCriteria } from 'utils/criteria';
 import { CqlLibraries } from 'engine/cql-to-elm';
 
 interface CriteriaContextInterface {
@@ -27,9 +21,8 @@ interface CriteriaContextInterface {
   addCriteria: (file: File) => void;
   addCqlCriteria: (cql: string) => void;
   deleteCriteria: (id: string) => void;
-  addElmCriteria: (elm: ElmLibrary) => Criteria[];
   addBuilderCriteria: (
-    criteria: BuilderModel,
+    criteria: CriteriaExecutionModel,
     label: string,
     criteriaSource: string | undefined
   ) => Criteria[];
@@ -80,10 +73,7 @@ export const CriteriaProvider: FC<CriteriaProviderProps> = memo(({ children }) =
         if (event.target?.result) {
           const rawContent = event.target.result as string;
           // TODO: more robust file type identification?
-          if (file.name.endsWith('.json')) {
-            const newCriteria = jsonToCriteria(rawContent);
-            if (newCriteria) setCriteria(currentCriteria => [...currentCriteria, ...newCriteria]);
-          } else if (file.name.endsWith('.cql')) {
+          if (file.name.endsWith('.cql')) {
             addCqlCriteria(rawContent);
           } else if (file.name.endsWith('.zip')) {
             const cqlLibraries: CqlLibraries = {};
@@ -111,16 +101,9 @@ export const CriteriaProvider: FC<CriteriaProviderProps> = memo(({ children }) =
     setCriteria(currentCriteria => currentCriteria.filter(criteria => criteria.id !== id));
   }, []);
 
-  const addElmCriteria = useCallback((elm: ElmLibrary): Criteria[] => {
-    const newCriteria = elmLibraryToCriteria(elm, undefined, undefined, true);
-    setCriteria(currentCriteria => [...currentCriteria, ...newCriteria]);
-
-    return newCriteria;
-  }, []);
-
   const addBuilderCriteria = useCallback(
     (
-      buildCriteria: BuilderModel,
+      buildCriteria: CriteriaExecutionModel,
       label: string,
       criteriaSource: string | undefined
     ): Criteria[] => {
@@ -151,7 +134,6 @@ export const CriteriaProvider: FC<CriteriaProviderProps> = memo(({ children }) =
         addCriteria,
         addCqlCriteria,
         deleteCriteria,
-        addElmCriteria,
         addBuilderCriteria
       }}
     >

--- a/src/components/StaticApp/Sidebar/ActionNodeEditor.tsx
+++ b/src/components/StaticApp/Sidebar/ActionNodeEditor.tsx
@@ -4,8 +4,6 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCheckCircle } from '@fortawesome/free-solid-svg-icons';
 import {
   setNodeAction,
-  createCQL,
-  setActionNodeElm,
   setActionResourceDisplay,
   setActionCode,
   setActionDescription,
@@ -16,7 +14,6 @@ import DropDown from 'components/elements/DropDown';
 import { ActionNode, Action, PathwayNode } from 'pathways-model';
 import useStyles from 'components/Sidebar/styles';
 import { TextField } from '@material-ui/core';
-import { convertBasicCQL } from 'engine/cql-to-elm';
 import { useCurrentPathwayContext } from 'components/StaticApp/CurrentPathwayProvider';
 import produce from 'immer';
 import { nodeTypeOptions } from 'utils/nodeUtils';
@@ -40,20 +37,6 @@ const ActionNodeEditor: FC<ActionNodeEditorProps> = ({ currentNode, changeNodeTy
   const { pathway, pathwayRef, setCurrentPathway } = useCurrentPathwayContext();
   const currentNodeStatic = useCurrentNodeStatic(pathway);
   const styles = useStyles();
-
-  const addActionCQL = useCallback(
-    (action: Action, currentNodeKey: string): void => {
-      if (!pathwayRef.current) return;
-
-      const cql = createCQL(action, currentNodeKey);
-      convertBasicCQL(cql).then(elm => {
-        // Disable lint for no-null assertion since it is already checked above
-        // eslint-disable-next-line
-        setCurrentPathway(setActionNodeElm(pathwayRef.current!, currentNodeKey, elm));
-      });
-    },
-    [pathwayRef, setCurrentPathway]
-  );
 
   const changeCode = useCallback(
     (event: ChangeEvent<{ value: string }>): void => {
@@ -86,11 +69,12 @@ const ActionNodeEditor: FC<ActionNodeEditorProps> = ({ currentNode, changeNodeTy
 
       const title = event?.target.value || '';
       const action = setActionTitle(currentNode.action, title);
-      setCurrentPathway(setNodeAction(pathwayRef.current, currentNode.key, resetDisplay(action)));
 
-      addActionCQL(action, currentNode.key);
+      const pathway = setNodeAction(pathwayRef.current, currentNode.key, resetDisplay(action));
+
+      setCurrentPathway(pathway);
     },
-    [currentNodeStatic, pathwayRef, setCurrentPathway, addActionCQL]
+    [currentNodeStatic, pathwayRef, setCurrentPathway]
   );
 
   const selectCodeSystem = useCallback(
@@ -111,11 +95,10 @@ const ActionNodeEditor: FC<ActionNodeEditorProps> = ({ currentNode, changeNodeTy
     }
 
     const action = setActionResourceDisplay(currentNode.action, 'Example Text');
-    setCurrentPathway(setNodeAction(pathwayRef.current, currentNode.key, action));
+    const pathway = setNodeAction(pathwayRef.current, currentNode.key, action);
 
-    // TODO: move addActionCQL to builder.ts
-    addActionCQL(action, currentNode.key);
-  }, [currentNodeStatic, pathwayRef, setCurrentPathway, addActionCQL]);
+    setCurrentPathway(pathway);
+  }, [currentNodeStatic, pathwayRef, setCurrentPathway]);
 
   const resetDisplay = (action: Action): Action => {
     return produce(action, (draftAction: Action) => {

--- a/src/components/StaticApp/Sidebar/BranchTransition.tsx
+++ b/src/components/StaticApp/Sidebar/BranchTransition.tsx
@@ -15,7 +15,7 @@ import useStyles from 'components/Sidebar/styles';
 import { useCurrentPathwayContext } from 'components/StaticApp/CurrentPathwayProvider';
 import { useCurrentCriteriaContext } from 'components/CurrentCriteriaProvider';
 import { useCriteriaBuilderContext } from 'components/CriteriaBuilderProvider';
-import { BuilderModel, Criteria } from 'criteria-model';
+import { Criteria, CriteriaExecutionModel } from 'criteria-model';
 import useCurrentNodeStatic from 'hooks/useCurrentNodeStatic';
 
 interface BranchTransitionProps {
@@ -57,11 +57,16 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition, currentNode }
   const transitionRef = useRef(transition);
   const transitionSelected = buildCriteriaSelected && currentCriteriaNodeId === transition.id;
   // Check if criteria was built by criteria builder
-  let builderElements: BuilderModel | null = null;
+  let builderElements: CriteriaExecutionModel | null = null;
   let builderCriteria: Criteria | undefined;
   if (transition.condition) {
     builderCriteria = criteria.find(c => c.id === transition.condition?.criteriaSource);
-    if (builderCriteria?.builder) builderElements = builderCriteria.builder;
+    if (builderCriteria?.builder)
+      builderElements = {
+        builder: builderCriteria.builder,
+        cql: builderCriteria.cql,
+        elm: builderCriteria.elm
+      };
   }
   const dislayEditCriteria = !transitionSelected && builderElements;
 
@@ -145,7 +150,7 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition, currentNode }
 
   const handleEditCriteria = useCallback((): void => {
     setCurrentCriteriaNodeId(transition.id);
-    setCurrentCriteria(builderElements as BuilderModel);
+    setCurrentCriteria(builderElements);
     if (builderCriteria?.label) setCriteriaName(builderCriteria?.label);
     if (!buildCriteriaSelected) setBuildCriteriaSelected(true);
     if (builderElements) setCriteriaBuilder(builderElements);
@@ -255,7 +260,7 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition, currentNode }
             fullWidth
             disabled
           />
-          <span className={styles.buildCriteriaText}>{builderElements?.text}</span>
+          <span className={styles.buildCriteriaText}>{builderElements?.builder?.text}</span>
           <div className={styles.buildCriteriaContainer}>
             <Button
               className={styles.cancelButton}
@@ -302,8 +307,8 @@ const BranchTransition: FC<BranchTransitionProps> = ({ transition, currentNode }
             value={criteriaName}
             fullWidth
           />
-          {currentCriteria?.text && (
-            <span className={styles.buildCriteriaText}>{currentCriteria.text}</span>
+          {currentCriteria?.builder?.text && (
+            <span className={styles.buildCriteriaText}>{currentCriteria.builder.text}</span>
           )}
           <div className={styles.buildCriteriaContainer}>
             <FormControlLabel

--- a/src/components/elements/ExportMenu/ExportMenu.tsx
+++ b/src/components/elements/ExportMenu/ExportMenu.tsx
@@ -56,6 +56,7 @@ const ExportMenu: FC<ExportMenuPropsInterface> = ({ pathway, anchorEl, closeMenu
         </MenuItem>
         <MenuItem onClick={handleDownloadCPG}>Export to CPG</MenuItem>
       </Menu>
+
       <Modal
         handleShowModal={showModal}
         handleCloseModal={handleCloseModal}

--- a/src/components/elements/ExportMenu/ExportMenu.tsx
+++ b/src/components/elements/ExportMenu/ExportMenu.tsx
@@ -1,10 +1,12 @@
-import React, { FC, memo, useCallback } from 'react';
+import React, { FC, memo, useCallback, useState } from 'react';
 import { Menu, MenuItem } from '@material-ui/core';
 import { useCurrentPathwayContext } from 'components/CurrentPathwayProvider';
 import { downloadPathway } from 'utils/builder';
 import { Pathway } from 'pathways-model';
 import usePathways from 'hooks/usePathways';
 import useCriteria from 'hooks/useCriteria';
+import Modal from 'components/elements/Modal';
+import Loading from 'components/elements/Loading';
 
 interface ContextualExportMenuProps {
   anchorEl: HTMLElement | null;
@@ -19,33 +21,50 @@ const ExportMenu: FC<ExportMenuPropsInterface> = ({ pathway, anchorEl, closeMenu
   const { pathways } = usePathways();
   const { criteria } = useCriteria();
 
-  const exportPathway = useCallback(() => {
-    if (pathway) downloadPathway(pathway, pathways, criteria);
-    else alert('No pathway to download!');
-    closeMenu();
-  }, [pathway, pathways, criteria, closeMenu]);
+  const [showModal, setShowModal] = useState<boolean>(false);
 
-  const exportCPG = useCallback(() => {
-    if (pathway) downloadPathway(pathway, pathways, criteria, true);
-    else alert('No pathway to download!');
-    closeMenu();
-  }, [pathway, pathways, criteria, closeMenu]);
+  const handleCloseModal = useCallback(() => setShowModal(false), [setShowModal]);
+
+  const handleDownload = useCallback(
+    (cpg: boolean) => {
+      if (pathway) {
+        setShowModal(true);
+        downloadPathway(pathway, pathways, criteria, cpg).then(() => setShowModal(false));
+      } else alert('No pathway to download!');
+      closeMenu();
+    },
+    [pathway, pathways, criteria, setShowModal, closeMenu]
+  );
+
+  const handleDownloadPathway = useCallback(() => handleDownload(false), [handleDownload]);
+
+  const handleDownloadCPG = useCallback(() => handleDownload(true), [handleDownload]);
 
   return (
-    <Menu
-      id="pathway-options-menu"
-      anchorEl={anchorEl}
-      getContentAnchorEl={null}
-      anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-      keepMounted
-      open={Boolean(anchorEl)}
-      onClose={closeMenu}
-    >
-      <MenuItem onClick={exportPathway}>
-        Export Pathway{pathway?.length && pathway.length > 1 ? 's' : ''}
-      </MenuItem>
-      <MenuItem onClick={exportCPG}>Export to CPG</MenuItem>
-    </Menu>
+    <>
+      <Menu
+        id="pathway-options-menu"
+        anchorEl={anchorEl}
+        getContentAnchorEl={null}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        keepMounted
+        open={Boolean(anchorEl)}
+        onClose={closeMenu}
+      >
+        <MenuItem onClick={handleDownloadPathway}>
+          Export Pathway{pathway?.length && pathway.length > 1 ? 's' : ''}
+        </MenuItem>
+        <MenuItem onClick={handleDownloadCPG}>Export to CPG</MenuItem>
+      </Menu>
+      <Modal
+        handleShowModal={showModal}
+        handleCloseModal={handleCloseModal}
+        headerTitle="Pathway Exporting"
+        headerSubtitle="Please wait while the pathway exports."
+      >
+        <Loading />
+      </Modal>
+    </>
   );
 };
 

--- a/src/components/elements/Modal/Modal.tsx
+++ b/src/components/elements/Modal/Modal.tsx
@@ -15,12 +15,12 @@ import useStyles from './styles';
 interface ModalProps {
   handleShowModal: boolean;
   handleCloseModal: () => void;
-  handleSaveModal: () => void;
+  handleSaveModal?: () => void;
   headerTitle: string;
   headerSubtitle: string;
   footerText?: ReactNode;
   hasSecondaryButton?: boolean;
-  submitButtonText: string;
+  submitButtonText?: string;
   children?: ReactNode;
 }
 
@@ -61,15 +61,17 @@ const Modal: FC<ModalProps> = ({
           </Button>
         )}
 
-        <Button
-          variant="contained"
-          color="secondary"
-          type="submit"
-          onClick={handleSaveModal}
-          className={styles.submitButton}
-        >
-          {submitButtonText}
-        </Button>
+        {submitButtonText && handleSaveModal !== undefined && (
+          <Button
+            variant="contained"
+            color="secondary"
+            type="submit"
+            onClick={handleSaveModal}
+            className={styles.submitButton}
+          >
+            {submitButtonText}
+          </Button>
+        )}
       </DialogActions>
     </Dialog>
   );

--- a/src/engine/cql-to-elm.ts
+++ b/src/engine/cql-to-elm.ts
@@ -11,7 +11,7 @@ const url = config.get('cqlToElmWebserviceUrl');
 
 export interface CqlLibraries {
   [name: string]: {
-    cql?: string;
+    cql: string;
     version?: string;
   };
 }

--- a/src/types/criteria-model.d.ts
+++ b/src/types/criteria-model.d.ts
@@ -19,7 +19,6 @@ declare module 'criteria-model' {
   interface Gender {
     type: 'gender';
     gender: string;
-    cql: string;
     text?: string;
   }
 
@@ -27,15 +26,10 @@ declare module 'criteria-model' {
     type: 'age';
     min: number;
     max: number;
-    cql: string;
     text?: string;
   }
 
   export type BuilderModel = Age | Gender;
-  export type Criteria = CriteriaModel &
-    (
-      | { builder: BuilderModel; elm?: ElmLibrary; cql?: string }
-      | { builder?: BuilderModel; elm: ElmLibrary; cql?: string }
-      | { builder?: BuilderModel; elm?: ElmLibrary; cql: string }
-    );
+  export type CriteriaExecutionModel = { builder?: BuilderModel; elm: ElmLibrary; cql: string };
+  export type Criteria = CriteriaModel & CriteriaExecutionModel;
 }

--- a/src/types/pathways-model.d.ts
+++ b/src/types/pathways-model.d.ts
@@ -70,7 +70,7 @@ declare module 'pathways-model' {
     };
   }
 
-  interface ActionCqlLibrary {
+  export interface ActionCqlLibrary {
     name: string;
     version: string;
     cql: string;

--- a/src/types/pathways-model.d.ts
+++ b/src/types/pathways-model.d.ts
@@ -35,8 +35,6 @@ declare module 'pathways-model' {
   }
 
   export interface ActionNode extends PathwayNode {
-    cql: string;
-    elm?: ElmLibrary;
     action: Action;
   }
 
@@ -70,5 +68,12 @@ declare module 'pathways-model' {
       elm?: ElmLibrary;
       criteriaSource?: string;
     };
+  }
+
+  interface ActionCqlLibrary {
+    name: string;
+    version: string;
+    cql: string;
+    nodeKey: string;
   }
 }

--- a/src/utils/CaminoExporter.ts
+++ b/src/utils/CaminoExporter.ts
@@ -76,8 +76,8 @@ export class CaminoExporter {
             if (!transition.condition.cql.startsWith(libraryIdentifier.id)) {
               transition.condition.cql = `${libraryIdentifier.id}.${transition.condition.cql}`;
             }
-          } else if (criteriaSource?.builder) {
-            builderDefines[criteriaSource.statement] = criteriaSource.builder.cql;
+          } else if (criteriaSource) {
+            builderDefines[criteriaSource.statement] = criteriaSource.cql;
 
             // prepend the library name
             transition.condition.cql = `${libraryName}.${transition.condition.cql}`;
@@ -101,7 +101,6 @@ export class CaminoExporter {
       const addtlLibraries = Object.values(includedCqlLibraries).map(l => l.cql);
       libraries.push(...addtlLibraries);
     }
-
     this.pathway.library = libraries;
 
     return this.pathway;

--- a/src/utils/__tests__/CaminoExporter.test.ts
+++ b/src/utils/__tests__/CaminoExporter.test.ts
@@ -78,15 +78,15 @@ const simplePathway: Pathway = {
 describe('convert pathway', () => {
   Object.keys(testPathways).forEach(name => {
     it(`correctly converts ${name} to a form that can be turned into JSON`, () => {
-      const exporter = new CaminoExporter(testPathways[name], []);
+      const exporter = new CaminoExporter(testPathways[name], [], []);
       const caminoPathway = exporter.export();
       JSON.stringify(caminoPathway, undefined, 2);
     });
   });
 
   it('does not prepend a library again if it is already prepended once', () => {
-    const firstExport = new CaminoExporter(simplePathway, [simpleCriteria]).export();
-    const secondExport = new CaminoExporter(firstExport, [simpleCriteria]).export();
+    const firstExport = new CaminoExporter(simplePathway, [simpleCriteria], []).export();
+    const secondExport = new CaminoExporter(firstExport, [simpleCriteria], []).export();
     expect(firstExport.nodes['Start'].transitions[0].condition?.cql).toBe('LIBFoo.isMale');
     expect(secondExport.nodes['Start'].transitions[0].condition?.cql).toBe('LIBFoo.isMale');
   });

--- a/src/utils/__tests__/builder.test.ts
+++ b/src/utils/__tests__/builder.test.ts
@@ -322,8 +322,8 @@ describe('builder interface update functions', () => {
 
   it('set navigational elm', () => {
     const elm = {};
-    const newPathway = Builder.setNavigationalElm(pathway, elm);
-    expect(newPathway.elm?.navigational).toEqual(elm);
+    const newPathway = Builder.setNavigationalElm(pathway, [elm]);
+    expect(newPathway.elm?.navigational).toEqual({ main: elm, libraries: [] });
   });
 
   it('set precondition elm', () => {
@@ -378,25 +378,6 @@ describe('builder interface update functions', () => {
     );
   });
 
-  it('set transition condition elm', () => {
-    const startNodeKey = 'T-test';
-    const transitionId = '1';
-    const newPathway = Builder.setTransitionConditionElm(
-      pathway,
-      startNodeKey,
-      transitionId,
-      criteria
-    );
-    expect(newPathway.nodes[startNodeKey].transitions[0].condition.cql).toBe('Tumor Size');
-  });
-
-  it('set action node elm', () => {
-    const key = 'Radiation';
-    const newPathway = Builder.setActionNodeElm(pathway, key, elm);
-    expect(newPathway.nodes[key].cql).toBe('Tumor Size');
-    expect(newPathway.nodes[key].elm).toEqual(elm);
-  });
-
   it('set node label', () => {
     const key = 'T-test';
 
@@ -410,14 +391,12 @@ describe('builder interface update functions', () => {
     it('converts a branch node into a action node', () => {
       const key = 'N-test';
       const newPathway = Builder.setNodeType(pathway, key, 'ServiceRequest');
-      expect(newPathway.nodes[key].cql).toEqual('');
       expect(newPathway.nodes[key].action).toBeDefined();
     });
 
     it('converts a action node into a branch node', () => {
       const key = 'Surgery';
       const newPathway = Builder.setNodeType(pathway, key, 'Observation');
-      expect(newPathway.nodes[key].cql).not.toBeDefined();
       expect(newPathway.nodes[key].action).not.toBeDefined();
     });
   });
@@ -485,7 +464,6 @@ describe('builder interface update functions', () => {
     it('converts a branch node into a action node', () => {
       const key = 'N-test';
       const newPathway = Builder.makeNodeAction(pathway, key);
-      expect(newPathway.nodes[key].cql).toEqual('');
       expect(newPathway.nodes[key].nodeTypeIsUndefined).not.toBeDefined();
       newPathway.nodes[key].transitions.forEach(transition => {
         expect(transition.condition).not.toBeDefined();
@@ -496,7 +474,6 @@ describe('builder interface update functions', () => {
       const key = 'N-test';
       Builder.makeNodeAction(pathway, key);
 
-      expect(pathway.nodes[key].cql).not.toBeDefined();
       expect(pathway.nodes[key].action).not.toBeDefined();
     });
   });
@@ -505,7 +482,6 @@ describe('builder interface update functions', () => {
     it('converts a action node intoa a branch node', () => {
       const key = 'Surgery';
       const newPathway = Builder.makeNodeBranch(pathway, key);
-      expect(newPathway.nodes[key].cql).not.toBeDefined();
       expect(newPathway.nodes[key].action).not.toBeDefined();
       expect(newPathway.nodes[key].nodeTypeIsUndefined).not.toBeDefined();
     });
@@ -514,7 +490,6 @@ describe('builder interface update functions', () => {
       const key = 'Surgery';
       Builder.makeNodeBranch(pathway, key);
 
-      expect(pathway.nodes[key].cql).toBeDefined();
       expect(pathway.nodes[key].action).toBeDefined();
     });
   });
@@ -596,7 +571,7 @@ describe('builder interface helper functions', () => {
       }
     };
     action.resource = medicationRequest;
-    let cql = Builder.createCQL(action, 'TestNode').replace(/\s+/g, '');
+    let cql = Builder.createCQL(action, 'TestNode').cql.replace(/\s+/g, '');
     expect(cql).toEqual(
       expect.stringContaining(
         `Tuple{ resourceType: 'MedicationRequest', id: R.id.value, status: R.status.value}`.replace(
@@ -621,7 +596,7 @@ describe('builder interface helper functions', () => {
       }
     };
     action.resource = serviceRequest;
-    cql = Builder.createCQL(action, 'TestNode').replace(/\s+/g, '');
+    cql = Builder.createCQL(action, 'TestNode').cql.replace(/\s+/g, '');
     expect(cql).toEqual(
       expect.stringContaining(
         `return Tuple{ resourceType: 'Procedure', id: R.id.value, status: R.status.value }`.replace(
@@ -645,7 +620,7 @@ describe('builder interface helper functions', () => {
       title: 'ChemotherapyTH'
     };
     action.resource = carePlan;
-    cql = Builder.createCQL(action, 'TestNode').replace(/\s+/g, '');
+    cql = Builder.createCQL(action, 'TestNode').cql.replace(/\s+/g, '');
     expect(cql).toEqual(
       expect.stringContaining(
         `[CarePlan] R where R.title.value='ChemotherapyTH'

--- a/src/utils/__tests__/regexes.test.ts
+++ b/src/utils/__tests__/regexes.test.ts
@@ -2,7 +2,9 @@ import {
   extractMultipartBoundary,
   extractMultipartFileName,
   extractJSONContent,
-  extractCQLInclude
+  extractCQLInclude,
+  extractCQLLibraryName,
+  extractCQLVersion
 } from 'utils/regexes';
 
 // sample response from https://github.com/cqframework/cql-translation-service
@@ -136,6 +138,28 @@ describe('extractCQLInclude', () => {
     if (result) {
       // typescript doesn't understand expect not null
       expect(result[1]).toEqual('FHIRHelpers');
+    }
+  });
+});
+
+describe('extractCQLLibraryName', () => {
+  it('correctly matches expected test', () => {
+    const result = extractCQLLibraryName.exec(sampleCQL);
+    expect(result).not.toBeNull();
+    if (result) {
+      // typescript doesn't understand expect not null
+      expect(result[1]).toEqual('DiabeticFootExam');
+    }
+  });
+});
+
+describe('extractCQLVersion', () => {
+  it('correctly matches expected test', () => {
+    const result = extractCQLVersion.exec(sampleCQL);
+    expect(result).not.toBeNull();
+    if (result) {
+      // typescript doesn't understand expect not null
+      expect(result[1]).toEqual('1.0.0');
     }
   });
 });

--- a/src/utils/cpg.ts
+++ b/src/utils/cpg.ts
@@ -358,8 +358,8 @@ export class CPGExporter {
                 }
               });
             }
-          } else if (criteriaSource?.builder) {
-            builderDefines[criteriaSource.statement] = criteriaSource.builder.cql;
+          } else if (criteriaSource) {
+            builderDefines[criteriaSource.statement] = criteriaSource.cql;
           }
         }
       }

--- a/src/utils/criteria.ts
+++ b/src/utils/criteria.ts
@@ -1,4 +1,4 @@
-import { BuilderModel, Criteria } from 'criteria-model';
+import { CriteriaExecutionModel, Criteria } from 'criteria-model';
 import { ElmLibrary, ElmStatement } from 'elm-model';
 import { convertBasicCQL, convertCQL, CqlLibraries } from 'engine/cql-to-elm';
 import shortid from 'shortid';
@@ -15,7 +15,7 @@ const DEFAULT_ELM_STATEMENTS = [
 
 export function elmLibraryToCriteria(
   elm: ElmLibrary,
-  cql: string | undefined = undefined,
+  cql: string,
   cqlLibraries: CqlLibraries | undefined = undefined,
   custom = false
 ): Criteria[] {
@@ -75,39 +75,35 @@ export function cqlToCriteria(cql: string | CqlLibraries): Promise<Criteria[]> {
         .map(key => {
           // Exclude current library from the list of cql libraries to pass to elmLibraryToCriteria
           const { [key]: keyToExclude, ...dependencies } = cql;
-          return elmLibraryToCriteria(elm[key], cql[key].cql, dependencies);
+          // eslint-disable-next-line
+          return elmLibraryToCriteria(elm[key], cql[key]!.cql, dependencies);
         })
         .flat(1);
     });
   }
 }
 
-export function jsonToCriteria(rawElm: string): Criteria[] | undefined {
-  const elm = JSON.parse(rawElm);
-  if (!elm.library?.identifier) {
-    alert('Please upload ELM file');
-    return;
-  }
-  return elmLibraryToCriteria(elm);
-}
-
 export function builderModelToCriteria(
-  criteria: BuilderModel,
+  criteria: CriteriaExecutionModel,
   label: string,
   id?: string
 ): Criteria {
+  // convert buildermodel to elm and add that to return
+
   return {
     id: id ? id : shortid.generate(),
     label,
     display: label,
     modified: Date.now(),
-    builder: criteria,
-    statement: label
+    builder: criteria.builder ?? undefined,
+    statement: label,
+    cql: criteria.cql,
+    elm: criteria.elm
   };
 }
 
 export function addBuilderCriteria(
-  buildCriteria: BuilderModel,
+  buildCriteria: CriteriaExecutionModel,
   label: string,
   criteriaSource: string | undefined
 ): Criteria[] {

--- a/src/utils/regexes.ts
+++ b/src/utils/regexes.ts
@@ -8,3 +8,7 @@ export const extractMultipartFileName = /Content-Disposition: form-data; name="(
 export const extractJSONContent = /(\{[^]*\})/;
 
 export const extractCQLInclude = /include .* called (.*)/;
+
+export const extractCQLLibraryName = /library ([^ ]*)/;
+
+export const extractCQLVersion = /version '(.*)'/;


### PR DESCRIPTION
Update the builder so the action node cql is only converted to ELM at export time. It then proceeds to add this to the elm. Since the conversion can take a couple seconds I also added a little modal showing the application is working on exporting the pathway.