### PR TITLE
Convert CQL to ELM

### DIFF
--- a/src/components/CriteriaList/CriteriaList.tsx
+++ b/src/components/CriteriaList/CriteriaList.tsx
@@ -12,7 +12,7 @@ import FileImportModal from 'components/FileImportModal';
 import useListCheckbox from 'hooks/useListCheckbox';
 import ConfirmationPopover from 'components/elements/ConfirmationPopover';
 import { deleteCriteria, readFile, updateCriteria } from 'utils/backend';
-import { cqlToCriteria, jsonToCriteria } from 'utils/criteria';
+import { cqlToCriteria } from 'utils/criteria';
 import useCriteria from 'hooks/useCriteria';
 import JSZip from 'jszip';
 import { CqlLibraries } from 'engine/cql-to-elm';
@@ -64,10 +64,7 @@ const CriteriaList: FC = () => {
           if (event.target?.result) {
             const rawContent = event.target.result as string;
             // TODO: more robust file type identification?
-            if (files[0].name.endsWith('.json')) {
-              const newCriteria = jsonToCriteria(rawContent);
-              if (newCriteria) newCriteria.forEach(criteria => mutateAddCriteria(criteria)); // eslint-disable-line
-            } else if (files[0].name.endsWith('.cql')) {
+            if (files[0].name.endsWith('.cql')) {
               addCqlCriteria(rawContent);
             } else if (files[0].name.endsWith('.zip')) {
               const cqlLibraries: CqlLibraries = {};
@@ -90,7 +87,7 @@ const CriteriaList: FC = () => {
       }
       closeImportModal();
     },
-    [mutateAddCriteria, closeImportModal, addCqlCriteria]
+    [closeImportModal, addCqlCriteria]
   );
 
   const [mutateDelete] = useMutation(deleteCriteria, {

--- a/src/components/Sidebar/ActionNodeEditor.tsx
+++ b/src/components/Sidebar/ActionNodeEditor.tsx
@@ -49,7 +49,7 @@ const ActionNodeEditor: FC<ActionNodeEditorProps> = ({ changeNodeType, currentNo
       convertBasicCQL(cql).then(elm => {
         // Disable lint for no-null assertion since it is already checked above
         // eslint-disable-next-line
-        setCurrentPathway(setActionNodeElm(pathwayRef.current!, currentNodeKey, elm));
+        //setCurrentPathway(setActionNodeElm(pathwayRef.current!, currentNodeKey, elm));
       });
     },
     [pathwayRef, setCurrentPathway]

--- a/src/components/Sidebar/ActionNodeEditor.tsx
+++ b/src/components/Sidebar/ActionNodeEditor.tsx
@@ -4,8 +4,6 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCheckCircle } from '@fortawesome/free-solid-svg-icons';
 import {
   setNodeAction,
-  createCQL,
-  setActionNodeElm,
   setActionResourceDisplay,
   setActionCode,
   setActionDescription,
@@ -16,7 +14,6 @@ import DropDown from 'components/elements/DropDown';
 import { ActionNode, Action, PathwayNode } from 'pathways-model';
 import useStyles from './styles';
 import { TextField } from '@material-ui/core';
-import { convertBasicCQL } from 'engine/cql-to-elm';
 import { useCurrentPathwayContext } from 'components/CurrentPathwayProvider';
 import produce from 'immer';
 import { nodeTypeOptions } from 'utils/nodeUtils';
@@ -40,20 +37,6 @@ const ActionNodeEditor: FC<ActionNodeEditorProps> = ({ changeNodeType, currentNo
   const { pathwayRef, setCurrentPathway } = useCurrentPathwayContext();
   const currentNodeStatic = useCurrentNodeStatic(pathwayRef.current) as ActionNode;
   const styles = useStyles();
-
-  const addActionCQL = useCallback(
-    (action: Action, currentNodeKey: string): void => {
-      if (!pathwayRef.current) return;
-
-      const cql = createCQL(action, currentNodeKey);
-      convertBasicCQL(cql).then(elm => {
-        // Disable lint for no-null assertion since it is already checked above
-        // eslint-disable-next-line
-        //setCurrentPathway(setActionNodeElm(pathwayRef.current!, currentNodeKey, elm));
-      });
-    },
-    [pathwayRef, setCurrentPathway]
-  );
 
   const changeCode = useCallback(
     (event: ChangeEvent<{ value: string }>): void => {
@@ -85,13 +68,16 @@ const ActionNodeEditor: FC<ActionNodeEditorProps> = ({ changeNodeType, currentNo
 
       const title = event?.target.value || '';
       const action = setActionTitle(currentNodeStatic.action, title);
-      setCurrentPathway(
-        setNodeAction(pathwayRef.current, currentNodeStatic.key, resetDisplay(action))
+
+      const pathway = setNodeAction(
+        pathwayRef.current,
+        currentNodeStatic.key,
+        resetDisplay(action)
       );
 
-      addActionCQL(action, currentNodeStatic.key);
+      setCurrentPathway(pathway);
     },
-    [currentNodeStatic, pathwayRef, setCurrentPathway, addActionCQL]
+    [currentNodeStatic, pathwayRef, setCurrentPathway]
   );
 
   const selectCodeSystem = useCallback(
@@ -113,11 +99,10 @@ const ActionNodeEditor: FC<ActionNodeEditorProps> = ({ changeNodeType, currentNo
     }
 
     const action = setActionResourceDisplay(currentNode.action, 'Example Text');
-    setCurrentPathway(setNodeAction(pathwayRef.current, currentNode.key, action));
+    const pathway = setNodeAction(pathwayRef.current, currentNode.key, action);
 
-    // TODO: move addActionCQL to builder.ts
-    addActionCQL(action, currentNode.key);
-  }, [currentNodeStatic, pathwayRef, setCurrentPathway, addActionCQL]);
+    setCurrentPathway(pathway);
+  }, [currentNodeStatic, pathwayRef, setCurrentPathway]);
 
   const resetDisplay = (action: Action): Action => {
     return produce(action, (draftAction: Action) => {

--- a/src/components/Sidebar/BranchTransition.tsx
+++ b/src/components/Sidebar/BranchTransition.tsx
@@ -1,6 +1,13 @@
 import React, { FC, memo, useState, useCallback, ChangeEvent, useMemo, useRef } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faSave, faTools, faTrashAlt, faThList, faEdit } from '@fortawesome/free-solid-svg-icons';
+import {
+  faSave,
+  faTools,
+  faTrashAlt,
+  faThList,
+  faEdit,
+  faSpinner
+} from '@fortawesome/free-solid-svg-icons';
 import DropDown from 'components/elements/DropDown';
 import { Button, Checkbox, FormControlLabel, TextField, Box } from '@material-ui/core';
 import {

--- a/src/components/StaticApp/CriteriaProvider.tsx
+++ b/src/components/StaticApp/CriteriaProvider.tsx
@@ -9,12 +9,11 @@ import React, {
   useEffect
 } from 'react';
 import JSZip from 'jszip';
-import { ElmLibrary } from 'elm-model';
 import config from 'utils/ConfigManager';
 import useGetService from 'components/StaticApp/Services';
 import { ServiceLoaded } from 'pathways-objects';
 import { Criteria, BuilderModel } from 'criteria-model';
-import { builderModelToCriteria, cqlToCriteria, elmLibraryToCriteria } from 'utils/criteria';
+import { builderModelToCriteria, cqlToCriteria } from 'utils/criteria';
 import { CqlLibraries } from 'engine/cql-to-elm';
 
 interface CriteriaContextInterface {
@@ -22,7 +21,6 @@ interface CriteriaContextInterface {
   addCriteria: (file: File) => void;
   addCqlCriteria: (cql: string) => void;
   deleteCriteria: (id: string) => void;
-  addElmCriteria: (elm: ElmLibrary) => Criteria[];
   addBuilderCriteria: (
     criteria: BuilderModel,
     label: string,
@@ -100,14 +98,7 @@ export const CriteriaProvider: FC<CriteriaProviderProps> = memo(({ children }) =
   );
 
   const deleteCriteria = useCallback((id: string) => {
-    setCriteria(currentCriteria => currentCriteria.filter(criteria => criteria.id !== id));
-  }, []);
-
-  const addElmCriteria = useCallback((elm: ElmLibrary): Criteria[] => {
-    const newCriteria = elmLibraryToCriteria(elm, undefined, undefined, true);
-    setCriteria(currentCriteria => [...currentCriteria, ...newCriteria]);
-
-    return newCriteria;
+    setCriteria(currentCriteria => currentCriteria.filter(c => c.id !== id));
   }, []);
 
   const addBuilderCriteria = useCallback(
@@ -144,7 +135,6 @@ export const CriteriaProvider: FC<CriteriaProviderProps> = memo(({ children }) =
         addCriteria,
         addCqlCriteria,
         deleteCriteria,
-        addElmCriteria,
         addBuilderCriteria
       }}
     >

--- a/src/components/StaticApp/Sidebar/ActionNodeEditor.tsx
+++ b/src/components/StaticApp/Sidebar/ActionNodeEditor.tsx
@@ -4,8 +4,6 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCheckCircle } from '@fortawesome/free-solid-svg-icons';
 import {
   setNodeAction,
-  createCQL,
-  setActionNodeElm,
   setActionResourceDisplay,
   setActionCode,
   setActionDescription,
@@ -16,7 +14,6 @@ import DropDown from 'components/elements/DropDown';
 import { ActionNode, Action, PathwayNode } from 'pathways-model';
 import useStyles from 'components/Sidebar/styles';
 import { TextField } from '@material-ui/core';
-import { convertBasicCQL } from 'engine/cql-to-elm';
 import { useCurrentPathwayContext } from 'components/StaticApp/CurrentPathwayProvider';
 import produce from 'immer';
 import { nodeTypeOptions } from 'utils/nodeUtils';
@@ -40,20 +37,6 @@ const ActionNodeEditor: FC<ActionNodeEditorProps> = ({ currentNode, changeNodeTy
   const { pathway, pathwayRef, setCurrentPathway } = useCurrentPathwayContext();
   const currentNodeStatic = useCurrentNodeStatic(pathway);
   const styles = useStyles();
-
-  const addActionCQL = useCallback(
-    (action: Action, currentNodeKey: string): void => {
-      if (!pathwayRef.current) return;
-
-      const cql = createCQL(action, currentNodeKey);
-      convertBasicCQL(cql).then(elm => {
-        // Disable lint for no-null assertion since it is already checked above
-        // eslint-disable-next-line
-        setCurrentPathway(setActionNodeElm(pathwayRef.current!, currentNodeKey, elm));
-      });
-    },
-    [pathwayRef, setCurrentPathway]
-  );
 
   const changeCode = useCallback(
     (event: ChangeEvent<{ value: string }>): void => {
@@ -86,11 +69,12 @@ const ActionNodeEditor: FC<ActionNodeEditorProps> = ({ currentNode, changeNodeTy
 
       const title = event?.target.value || '';
       const action = setActionTitle(currentNode.action, title);
-      setCurrentPathway(setNodeAction(pathwayRef.current, currentNode.key, resetDisplay(action)));
 
-      addActionCQL(action, currentNode.key);
+      const pathway = setNodeAction(pathwayRef.current, currentNode.key, resetDisplay(action));
+
+      setCurrentPathway(pathway);
     },
-    [currentNodeStatic, pathwayRef, setCurrentPathway, addActionCQL]
+    [currentNodeStatic, pathwayRef, setCurrentPathway]
   );
 
   const selectCodeSystem = useCallback(
@@ -111,11 +95,10 @@ const ActionNodeEditor: FC<ActionNodeEditorProps> = ({ currentNode, changeNodeTy
     }
 
     const action = setActionResourceDisplay(currentNode.action, 'Example Text');
-    setCurrentPathway(setNodeAction(pathwayRef.current, currentNode.key, action));
+    const pathway = setNodeAction(pathwayRef.current, currentNode.key, action);
 
-    // TODO: move addActionCQL to builder.ts
-    addActionCQL(action, currentNode.key);
-  }, [currentNodeStatic, pathwayRef, setCurrentPathway, addActionCQL]);
+    setCurrentPathway(pathway);
+  }, [currentNodeStatic, pathwayRef, setCurrentPathway]);
 
   const resetDisplay = (action: Action): Action => {
     return produce(action, (draftAction: Action) => {

--- a/src/components/elements/ExportMenu/ExportMenu.tsx
+++ b/src/components/elements/ExportMenu/ExportMenu.tsx
@@ -56,6 +56,7 @@ const ExportMenu: FC<ExportMenuPropsInterface> = ({ pathway, anchorEl, closeMenu
         </MenuItem>
         <MenuItem onClick={handleDownloadCPG}>Export to CPG</MenuItem>
       </Menu>
+
       <Modal
         handleShowModal={showModal}
         handleCloseModal={handleCloseModal}

--- a/src/components/elements/ExportMenu/ExportMenu.tsx
+++ b/src/components/elements/ExportMenu/ExportMenu.tsx
@@ -1,10 +1,12 @@
-import React, { FC, memo, useCallback } from 'react';
+import React, { FC, memo, useCallback, useState } from 'react';
 import { Menu, MenuItem } from '@material-ui/core';
 import { useCurrentPathwayContext } from 'components/CurrentPathwayProvider';
 import { downloadPathway } from 'utils/builder';
 import { Pathway } from 'pathways-model';
 import usePathways from 'hooks/usePathways';
 import useCriteria from 'hooks/useCriteria';
+import Modal from 'components/elements/Modal';
+import Loading from 'components/elements/Loading';
 
 interface ContextualExportMenuProps {
   anchorEl: HTMLElement | null;
@@ -19,33 +21,50 @@ const ExportMenu: FC<ExportMenuPropsInterface> = ({ pathway, anchorEl, closeMenu
   const { pathways } = usePathways();
   const { criteria } = useCriteria();
 
-  const exportPathway = useCallback(() => {
-    if (pathway) downloadPathway(pathway, pathways, criteria);
-    else alert('No pathway to download!');
-    closeMenu();
-  }, [pathway, pathways, criteria, closeMenu]);
+  const [showModal, setShowModal] = useState<boolean>(false);
 
-  const exportCPG = useCallback(() => {
-    if (pathway) downloadPathway(pathway, pathways, criteria, true);
-    else alert('No pathway to download!');
-    closeMenu();
-  }, [pathway, pathways, criteria, closeMenu]);
+  const handleCloseModal = useCallback(() => setShowModal(false), [setShowModal]);
+
+  const handleDownload = useCallback(
+    (cpg: boolean) => {
+      if (pathway) {
+        setShowModal(true);
+        downloadPathway(pathway, pathways, criteria, cpg).then(() => setShowModal(false));
+      } else alert('No pathway to download!');
+      closeMenu();
+    },
+    [pathway, pathways, criteria, setShowModal, closeMenu]
+  );
+
+  const handleDownloadPathway = useCallback(() => handleDownload(false), [handleDownload]);
+
+  const handleDownloadCPG = useCallback(() => handleDownload(true), [handleDownload]);
 
   return (
-    <Menu
-      id="pathway-options-menu"
-      anchorEl={anchorEl}
-      getContentAnchorEl={null}
-      anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-      keepMounted
-      open={Boolean(anchorEl)}
-      onClose={closeMenu}
-    >
-      <MenuItem onClick={exportPathway}>
-        Export Pathway{pathway?.length && pathway.length > 1 ? 's' : ''}
-      </MenuItem>
-      <MenuItem onClick={exportCPG}>Export to CPG</MenuItem>
-    </Menu>
+    <>
+      <Menu
+        id="pathway-options-menu"
+        anchorEl={anchorEl}
+        getContentAnchorEl={null}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        keepMounted
+        open={Boolean(anchorEl)}
+        onClose={closeMenu}
+      >
+        <MenuItem onClick={handleDownloadPathway}>
+          Export Pathway{pathway?.length && pathway.length > 1 ? 's' : ''}
+        </MenuItem>
+        <MenuItem onClick={handleDownloadCPG}>Export to CPG</MenuItem>
+      </Menu>
+      <Modal
+        handleShowModal={showModal}
+        handleCloseModal={handleCloseModal}
+        headerTitle="Pathway Exporting"
+        headerSubtitle="Please wait while the pathway exports."
+      >
+        <Loading />
+      </Modal>
+    </>
   );
 };
 

--- a/src/components/elements/Modal/Modal.tsx
+++ b/src/components/elements/Modal/Modal.tsx
@@ -15,12 +15,12 @@ import useStyles from './styles';
 interface ModalProps {
   handleShowModal: boolean;
   handleCloseModal: () => void;
-  handleSaveModal: () => void;
+  handleSaveModal?: () => void;
   headerTitle: string;
   headerSubtitle: string;
   footerText?: ReactNode;
   hasSecondaryButton?: boolean;
-  submitButtonText: string;
+  submitButtonText?: string;
   children?: ReactNode;
 }
 
@@ -61,15 +61,17 @@ const Modal: FC<ModalProps> = ({
           </Button>
         )}
 
-        <Button
-          variant="contained"
-          color="secondary"
-          type="submit"
-          onClick={handleSaveModal}
-          className={styles.submitButton}
-        >
-          {submitButtonText}
-        </Button>
+        {submitButtonText && handleSaveModal !== undefined && (
+          <Button
+            variant="contained"
+            color="secondary"
+            type="submit"
+            onClick={handleSaveModal}
+            className={styles.submitButton}
+          >
+            {submitButtonText}
+          </Button>
+        )}
       </DialogActions>
     </Dialog>
   );

--- a/src/engine/cql-to-elm.ts
+++ b/src/engine/cql-to-elm.ts
@@ -11,7 +11,7 @@ const url = config.get('cqlToElmWebserviceUrl');
 
 export interface CqlLibraries {
   [name: string]: {
-    cql?: string;
+    cql: string;
     version?: string;
   };
 }

--- a/src/types/criteria-model.d.ts
+++ b/src/types/criteria-model.d.ts
@@ -1,11 +1,11 @@
 declare module 'criteria-model' {
-  import { ElmLibrary } from 'elm-model';
-
-  export interface CriteriaModel {
+  export interface Criteria {
     id: string;
     label: string;
     display: string;
+    cql: string;
     version?: string;
+    builder?: BuilderModel;
     modified: number;
     statement: string;
     cqlLibraries?: {
@@ -32,10 +32,4 @@ declare module 'criteria-model' {
   }
 
   export type BuilderModel = Age | Gender;
-  export type Criteria = CriteriaModel &
-    (
-      | { builder: BuilderModel; elm?: ElmLibrary; cql?: string }
-      | { builder?: BuilderModel; elm: ElmLibrary; cql?: string }
-      | { builder?: BuilderModel; elm?: ElmLibrary; cql: string }
-    );
 }

--- a/src/types/pathways-model.d.ts
+++ b/src/types/pathways-model.d.ts
@@ -65,7 +65,6 @@ declare module 'pathways-model' {
     condition?: {
       description: string;
       cql: string;
-      elm?: ElmLibrary;
       criteriaSource?: string;
     };
   }

--- a/src/types/pathways-model.d.ts
+++ b/src/types/pathways-model.d.ts
@@ -35,8 +35,6 @@ declare module 'pathways-model' {
   }
 
   export interface ActionNode extends PathwayNode {
-    cql: string;
-    elm?: ElmLibrary;
     action: Action;
   }
 
@@ -70,5 +68,12 @@ declare module 'pathways-model' {
       elm?: ElmLibrary;
       criteriaSource?: string;
     };
+  }
+
+  interface ActionCqlLibrary {
+    name: string;
+    version: string;
+    cql: string;
+    nodeKey: string;
   }
 }

--- a/src/utils/CaminoExporter.ts
+++ b/src/utils/CaminoExporter.ts
@@ -58,7 +58,7 @@ export class CaminoExporter {
             const transitionLibraryNameRegex = extractCQLLibraryName.exec(criteriaSource.cql);
             const transitionLibraryVersionRegex = extractCQLVersion.exec(criteriaSource.cql);
             if (transitionLibraryNameRegex && transitionLibraryVersionRegex) {
-              const transitionLibraryName = transitionLibraryNameRegex[1];
+              const transitionLibraryName = transitionLibraryNameRegex[1].replaceAll('"', '');
               const transitionLibraryVersion = transitionLibraryVersionRegex[1];
               includedCqlLibraries[transitionLibraryName] = {
                 cql: criteriaSource.cql,

--- a/src/utils/CaminoExporter.ts
+++ b/src/utils/CaminoExporter.ts
@@ -3,7 +3,7 @@ import { Criteria } from 'criteria-model';
 import { v4 as uuidv4 } from 'uuid';
 import { deepCopyPathway } from './nodeUtils';
 import { constructCqlLibrary, IncludedCqlLibraries } from './export';
-import { convertBasicCQL, convertCQL } from 'engine/cql-to-elm';
+import { convertCQL } from 'engine/cql-to-elm';
 import { ElmLibrary } from 'elm-model';
 import { setNavigationalElm } from './builder';
 import { extractCQLLibraryName, extractCQLVersion } from './regexes';

--- a/src/utils/CaminoExporter.ts
+++ b/src/utils/CaminoExporter.ts
@@ -58,7 +58,7 @@ export class CaminoExporter {
             const transitionLibraryNameRegex = extractCQLLibraryName.exec(criteriaSource.cql);
             const transitionLibraryVersionRegex = extractCQLVersion.exec(criteriaSource.cql);
             if (transitionLibraryNameRegex && transitionLibraryVersionRegex) {
-              const transitionLibraryName = transitionLibraryNameRegex[1].replaceAll('"', '');
+              const transitionLibraryName = transitionLibraryNameRegex[1].replace(/"/g, '');
               const transitionLibraryVersion = transitionLibraryVersionRegex[1];
               includedCqlLibraries[transitionLibraryName] = {
                 cql: criteriaSource.cql,

--- a/src/utils/__tests__/CaminoExporter.test.ts
+++ b/src/utils/__tests__/CaminoExporter.test.ts
@@ -79,15 +79,20 @@ describe('convert pathway', () => {
   Object.keys(testPathways).forEach(name => {
     it(`correctly converts ${name} to a form that can be turned into JSON`, () => {
       const exporter = new CaminoExporter(testPathways[name], [], []);
-      const caminoPathway = exporter.export();
-      JSON.stringify(caminoPathway, undefined, 2);
+      exporter.export().then(caminoPathway => JSON.stringify(caminoPathway, undefined, 2));
     });
   });
 
   it('does not prepend a library again if it is already prepended once', () => {
-    const firstExport = new CaminoExporter(simplePathway, [simpleCriteria], []).export();
-    const secondExport = new CaminoExporter(firstExport, [simpleCriteria], []).export();
-    expect(firstExport.nodes['Start'].transitions[0].condition?.cql).toBe('LIBFoo.isMale');
-    expect(secondExport.nodes['Start'].transitions[0].condition?.cql).toBe('LIBFoo.isMale');
+    const firstExporter = new CaminoExporter(simplePathway, [simpleCriteria], []);
+    firstExporter.export().then(firstExport => {
+      expect(firstExport.nodes['Start'].transitions[0].condition?.cql).toBe('LIBFoo.isMale');
+      const secondExporter = new CaminoExporter(firstExport, [simpleCriteria], []);
+      secondExporter
+        .export()
+        .then(secondExport =>
+          expect(secondExport.nodes['Start'].transitions[0].condition?.cql).toBe('LIBFoo.isMale')
+        );
+    });
   });
 });

--- a/src/utils/__tests__/CaminoExporter.test.ts
+++ b/src/utils/__tests__/CaminoExporter.test.ts
@@ -78,15 +78,15 @@ const simplePathway: Pathway = {
 describe('convert pathway', () => {
   Object.keys(testPathways).forEach(name => {
     it(`correctly converts ${name} to a form that can be turned into JSON`, () => {
-      const exporter = new CaminoExporter(testPathways[name], []);
+      const exporter = new CaminoExporter(testPathways[name], [], []);
       const caminoPathway = exporter.export();
       JSON.stringify(caminoPathway, undefined, 2);
     });
   });
 
   it('does not prepend a library again if it is already prepended once', () => {
-    const firstExport = new CaminoExporter(simplePathway, [simpleCriteria]).export();
-    const secondExport = new CaminoExporter(firstExport, [simpleCriteria]).export();
+    const firstExport = new CaminoExporter(simplePathway, [simpleCriteria], []).export();
+    const secondExport = new CaminoExporter(firstExport, [simpleCriteria], []).export();
     expect(firstExport.nodes['Start'].transitions[0].condition?.cql).toBe('LIBFoo.isMale');
     expect(secondExport.nodes['Start'].transitions[0].condition?.cql).toBe('LIBFoo.isMale');
   });

--- a/src/utils/__tests__/builder.test.ts
+++ b/src/utils/__tests__/builder.test.ts
@@ -322,8 +322,8 @@ describe('builder interface update functions', () => {
 
   it('set navigational elm', () => {
     const elm = {};
-    const newPathway = Builder.setNavigationalElm(pathway, elm);
-    expect(newPathway.elm?.navigational).toEqual(elm);
+    const newPathway = Builder.setNavigationalElm(pathway, [elm]);
+    expect(newPathway.elm?.navigational).toEqual({ main: elm, libraries: [] });
   });
 
   it('set precondition elm', () => {
@@ -378,25 +378,6 @@ describe('builder interface update functions', () => {
     );
   });
 
-  it('set transition condition elm', () => {
-    const startNodeKey = 'T-test';
-    const transitionId = '1';
-    const newPathway = Builder.setTransitionConditionElm(
-      pathway,
-      startNodeKey,
-      transitionId,
-      criteria
-    );
-    expect(newPathway.nodes[startNodeKey].transitions[0].condition.cql).toBe('Tumor Size');
-  });
-
-  it('set action node elm', () => {
-    const key = 'Radiation';
-    const newPathway = Builder.setActionNodeElm(pathway, key, elm);
-    expect(newPathway.nodes[key].cql).toBe('Tumor Size');
-    expect(newPathway.nodes[key].elm).toEqual(elm);
-  });
-
   it('set node label', () => {
     const key = 'T-test';
 
@@ -410,14 +391,12 @@ describe('builder interface update functions', () => {
     it('converts a branch node into a action node', () => {
       const key = 'N-test';
       const newPathway = Builder.setNodeType(pathway, key, 'ServiceRequest');
-      expect(newPathway.nodes[key].cql).toEqual('');
       expect(newPathway.nodes[key].action).toBeDefined();
     });
 
     it('converts a action node into a branch node', () => {
       const key = 'Surgery';
       const newPathway = Builder.setNodeType(pathway, key, 'Observation');
-      expect(newPathway.nodes[key].cql).not.toBeDefined();
       expect(newPathway.nodes[key].action).not.toBeDefined();
     });
   });
@@ -485,7 +464,6 @@ describe('builder interface update functions', () => {
     it('converts a branch node into a action node', () => {
       const key = 'N-test';
       const newPathway = Builder.makeNodeAction(pathway, key);
-      expect(newPathway.nodes[key].cql).toEqual('');
       expect(newPathway.nodes[key].nodeTypeIsUndefined).not.toBeDefined();
       newPathway.nodes[key].transitions.forEach(transition => {
         expect(transition.condition).not.toBeDefined();
@@ -496,7 +474,6 @@ describe('builder interface update functions', () => {
       const key = 'N-test';
       Builder.makeNodeAction(pathway, key);
 
-      expect(pathway.nodes[key].cql).not.toBeDefined();
       expect(pathway.nodes[key].action).not.toBeDefined();
     });
   });
@@ -505,7 +482,6 @@ describe('builder interface update functions', () => {
     it('converts a action node intoa a branch node', () => {
       const key = 'Surgery';
       const newPathway = Builder.makeNodeBranch(pathway, key);
-      expect(newPathway.nodes[key].cql).not.toBeDefined();
       expect(newPathway.nodes[key].action).not.toBeDefined();
       expect(newPathway.nodes[key].nodeTypeIsUndefined).not.toBeDefined();
     });
@@ -514,7 +490,6 @@ describe('builder interface update functions', () => {
       const key = 'Surgery';
       Builder.makeNodeBranch(pathway, key);
 
-      expect(pathway.nodes[key].cql).toBeDefined();
       expect(pathway.nodes[key].action).toBeDefined();
     });
   });
@@ -596,7 +571,7 @@ describe('builder interface helper functions', () => {
       }
     };
     action.resource = medicationRequest;
-    let cql = Builder.createCQL(action, 'TestNode').replace(/\s+/g, '');
+    let cql = Builder.createCQL(action, 'TestNode').cql.replace(/\s+/g, '');
     expect(cql).toEqual(
       expect.stringContaining(
         `Tuple{ resourceType: 'MedicationRequest', id: R.id.value, status: R.status.value}`.replace(
@@ -621,7 +596,7 @@ describe('builder interface helper functions', () => {
       }
     };
     action.resource = serviceRequest;
-    cql = Builder.createCQL(action, 'TestNode').replace(/\s+/g, '');
+    cql = Builder.createCQL(action, 'TestNode').cql.replace(/\s+/g, '');
     expect(cql).toEqual(
       expect.stringContaining(
         `return Tuple{ resourceType: 'Procedure', id: R.id.value, status: R.status.value }`.replace(
@@ -645,7 +620,7 @@ describe('builder interface helper functions', () => {
       title: 'ChemotherapyTH'
     };
     action.resource = carePlan;
-    cql = Builder.createCQL(action, 'TestNode').replace(/\s+/g, '');
+    cql = Builder.createCQL(action, 'TestNode').cql.replace(/\s+/g, '');
     expect(cql).toEqual(
       expect.stringContaining(
         `[CarePlan] R where R.title.value='ChemotherapyTH'

--- a/src/utils/__tests__/builder.test.ts
+++ b/src/utils/__tests__/builder.test.ts
@@ -357,7 +357,6 @@ describe('builder interface update functions', () => {
       condition: {
         description: 'test description',
         cql: 'Tumor Size',
-        elm: elm,
         criteriaSource: '1'
       }
     };

--- a/src/utils/__tests__/regexes.test.ts
+++ b/src/utils/__tests__/regexes.test.ts
@@ -2,7 +2,9 @@ import {
   extractMultipartBoundary,
   extractMultipartFileName,
   extractJSONContent,
-  extractCQLInclude
+  extractCQLInclude,
+  extractCQLLibraryName,
+  extractCQLVersion
 } from 'utils/regexes';
 
 // sample response from https://github.com/cqframework/cql-translation-service
@@ -136,6 +138,28 @@ describe('extractCQLInclude', () => {
     if (result) {
       // typescript doesn't understand expect not null
       expect(result[1]).toEqual('FHIRHelpers');
+    }
+  });
+});
+
+describe('extractCQLLibraryName', () => {
+  it('correctly matches expected test', () => {
+    const result = extractCQLLibraryName.exec(sampleCQL);
+    expect(result).not.toBeNull();
+    if (result) {
+      // typescript doesn't understand expect not null
+      expect(result[1]).toEqual('DiabeticFootExam');
+    }
+  });
+});
+
+describe('extractCQLVersion', () => {
+  it('correctly matches expected test', () => {
+    const result = extractCQLVersion.exec(sampleCQL);
+    expect(result).not.toBeNull();
+    if (result) {
+      // typescript doesn't understand expect not null
+      expect(result[1]).toEqual('1.0.0');
     }
   });
 });

--- a/src/utils/criteria.ts
+++ b/src/utils/criteria.ts
@@ -13,12 +13,16 @@ const DEFAULT_ELM_STATEMENTS = [
   'Errors'
 ];
 
-export function elmLibraryToCriteria(
+function elmLibraryToCriteria(
   elm: ElmLibrary,
-  cql: string | undefined = undefined,
+  cql: string,
   cqlLibraries: CqlLibraries | undefined = undefined,
   custom = false
 ): Criteria[] {
+  // NOTE: the elm library is not used on the criteria anymore but this
+  //  method is still used to iterate over all statements. It is easier
+  //  to do this in ELM than in CQL even though it is not optimal.
+
   // the cql-to-elm webservice always responds with ELM
   // even if the CQL was complete garbage
   // TODO: consider showing the error messages from the annotations?
@@ -37,7 +41,7 @@ export function elmLibraryToCriteria(
     );
   }
   if (!elmStatements) {
-    alert('No elm statement found in that file');
+    alert('No statement found in that file');
     return [];
   }
   const labelTitle = custom
@@ -50,7 +54,6 @@ export function elmLibraryToCriteria(
       display: statement.name,
       version: elm.library.identifier.version,
       modified: Date.now(),
-      elm: elm,
       cql: cql,
       statement: statement.name,
       ...(cqlLibraries && { cqlLibraries })

--- a/src/utils/criteria.ts
+++ b/src/utils/criteria.ts
@@ -103,7 +103,6 @@ export function builderModelToCriteria(
   return cqlToCriteria(cqlLibrary).then(newCriteriaList => {
     const newCriteria = newCriteriaList[0];
     newCriteria.builder = criteria;
-    console.log(newCriteria);
     return newCriteria;
   });
 }

--- a/src/utils/regexes.ts
+++ b/src/utils/regexes.ts
@@ -8,3 +8,7 @@ export const extractMultipartFileName = /Content-Disposition: form-data; name="(
 export const extractJSONContent = /(\{[^]*\})/;
 
 export const extractCQLInclude = /include .* called (.*)/;
+
+export const extractCQLLibraryName = /library ([^ ]*)/;
+
+export const extractCQLVersion = /version '(.*)'/;


### PR DESCRIPTION
Fixed action node cql to only be converted to ELM once. Updates how ELM is handled in the builder and it removes it as a property from all fields except for `pathway.elm`. The navigational elm is now set at export using the pathway libraries.